### PR TITLE
Add qutip project ideas

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,6 +271,17 @@
     <p class="subtitle"><a name="project-ideas">Project Ideas</a></p>
 
     <p>
+        Unitary Fund is supporting the development of
+        <a href="http://www.qutip.org/">QuTiP</a>, the Quantum Toolbox in
+        Python. Interested students can apply to propose a code project in
+        QuTiP and be mentored by the core developers for a 3-month period,
+        working remotely, similarly to the Google Summer of Code. A list of
+        <a href="https://github.com/qutip/qutip/wiki/Google-Summer-of-Code-2020">
+        project ideas</a> is available from the QuTiP wiki.
+        Applications are open all-year-round.
+    </p>
+
+    <p>
         <a href="https://www.cgranade.com/">Chris Granade</a> - a senior developer on Microsoft's open
         source <a href="https://www.microsoft.com/en-ca/quantum/development-kit">Quantum Development Kit</a> -
         has some suggestions:


### PR DESCRIPTION
Add QuTiP project ideas for interested students. Says that Unitary Fund would support applications for remote code projects (~3-months long), similarly to Google Summer of Code, but all-year-round. 