### PR TITLE
Add favicon to Q1 blogpost page

### DIFF
--- a/posts/Q1_2020.html
+++ b/posts/Q1_2020.html
@@ -5,6 +5,11 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    
+    <link rel="apple-touch-icon" sizes="180x180" href="../favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../favicon/favicon-16x16.png">
+    <link rel="manifest" href="../favicon/site.webmanifest">
 
     <title>Unitary Fund</title>
     <!-- CSS -->


### PR DESCRIPTION
Missed that in #10. By the way the favicon elsewhere looks good on Chrome and Mozilla from mobile and desktop.