### PR TITLE
Add link to mitiq github

### DIFF
--- a/mitiq.html
+++ b/mitiq.html
@@ -75,7 +75,7 @@
                         </button>
                   </div>
                   <p class="subtitle leading-arrow">Quantum computers have errors</p>
-                  <p><b>Mitiq</b> is a cross platform compiler that makes your programs robust to those errors.</p>
+                  <p><b><a href="https://github.com/unitaryfund/mitiq">Mitiq</a></b> is a cross platform compiler that makes your programs robust to those errors.</p>
                   <div class="video-container">
                     <div class="col-2-3">
                       <video autoplay muted loop>


### PR DESCRIPTION
fixes #36 

I'm not sure who the intended audience is for the page. I expect a link of a software's name to resolve to its code, but I'm not sure everyone does.

![image](https://user-images.githubusercontent.com/2541209/95839913-66242680-0cf8-11eb-8a38-0b7a315f3843.png)
