### PR TITLE
Moving COC and adding links to from page footers.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at info@unitary.fund. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/faq.html
+++ b/faq.html
@@ -165,7 +165,7 @@
 
                     </p>
                     <footer class="footer leading-arrow light-arrow">
-                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br>
+                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>. <br> <br>
                         If you have suggestions for changes then please open up a pull request!
                         <br>
                         <br>

--- a/grants.html
+++ b/grants.html
@@ -322,7 +322,7 @@
                         </li><br>
                     </ul>
                     <footer class="footer leading-arrow light-arrow">
-                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br>
+                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>. <br> <br>
                         If you have suggestions for changes then please open up a pull request!
                         <br>
                         <br>

--- a/ideas.html
+++ b/ideas.html
@@ -93,7 +93,7 @@
                         </ul>
                     </p>
                     <footer class="footer leading-arrow light-arrow">
-                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br>
+                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>. <br> <br>
                         If you have suggestions for changes then please open up a pull request!
                         <br>
                         <br>

--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
                         <a href="http://willzeng.com/", target="_blank">Will Zeng</a>.
                     </p>
                     <footer class="footer leading-arrow light-arrow">
-                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br>
+                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>. <br> <br>
                         If you have suggestions for changes then please open up a pull request!
                         <br>
                         <br>

--- a/mitiq.html
+++ b/mitiq.html
@@ -107,7 +107,7 @@
                   <p>If you want to use Mitiq, just fill out this form.</p>
                   <iframe class="airtable-embed airtable-dynamic-height" src="https://airtable.com/embed/shrAdEP3XsCy4V0TA?backgroundColor=blue" frameborder="0" onmousewheel="" width="100%" height="853" style="background: transparent; border: 1px solid #ccc;"></iframe>
                   <footer class="footer leading-arrow light-arrow">
-                    This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br>
+                    This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>. <br> <br>
                     If you have suggestions for changes then please open up a pull request!
                     <br>
                     <br>

--- a/posts/Q1_2020.html
+++ b/posts/Q1_2020.html
@@ -204,7 +204,7 @@
             
                     </section>
                     <footer class="footer leading-arrow light-arrow">
-                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br>
+                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>. <br> <br>
                         If you have suggestions for changes then please open up a pull request!
                         <br>
                         <br>

--- a/posts/Q2_2020.html
+++ b/posts/Q2_2020.html
@@ -136,7 +136,7 @@
             
                     </section>
                     <footer class="footer leading-arrow light-arrow">
-                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br>
+                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>. <br> <br>
                         If you have suggestions for changes then please open up a pull request!
                         <br>
                         <br>

--- a/posts/Q3_2020.html
+++ b/posts/Q3_2020.html
@@ -128,7 +128,7 @@
 
                     </section>
                     <footer class="footer leading-arrow light-arrow">
-                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br>
+                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>. <br> <br>
                         If you have suggestions for changes then please open up a pull request!
                         <br>
                         <br>

--- a/posts/advisory_board.html
+++ b/posts/advisory_board.html
@@ -134,7 +134,7 @@
             
                     </section>
                     <footer class="footer leading-arrow light-arrow">
-                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br>
+                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>. <br> <br>
                         If you have suggestions for changes then please open up a pull request!
                         <br>
                         <br>

--- a/posts/high_school_resources.html
+++ b/posts/high_school_resources.html
@@ -327,7 +327,7 @@
             
                     </section>
                     <footer class="footer leading-arrow light-arrow">
-                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br>
+                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>. <br> <br>
                         If you have suggestions for changes then please open up a pull request!
                         <br>
                         <br>

--- a/posts/mitiq.html
+++ b/posts/mitiq.html
@@ -146,7 +146,7 @@
             
                     </section>
                     <footer class="footer leading-arrow light-arrow">
-                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br>
+                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>. <br> <br>
                         If you have suggestions for changes then please open up a pull request!
                         <br>
                         <br>

--- a/posts/unitary_labs_intro.html
+++ b/posts/unitary_labs_intro.html
@@ -139,7 +139,7 @@
             
                     </section>
                     <footer class="footer leading-arrow light-arrow">
-                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br>
+                        This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>. <br> <br>
                         If you have suggestions for changes then please open up a pull request!
                         <br>
                         <br>


### PR DESCRIPTION
I need a way to publicly link to our COC and have just moved the internal one external and added a link to it in the site footer, but obv tons of other places on the site to link. Also its a *.md file and not an HTML page so GitHub can auto-recognize it as such and make nice links for.