### PR TITLE
update_qsurface

### DIFF
--- a/grants.html
+++ b/grants.html
@@ -124,12 +124,13 @@
                             <img class="grant-image" src="/images/dummy.png" alt="grant" />
                             <p>
                             To <a class="recipient-link" href="https://watermarkhu.nl/">Mark Shui
-                            Hu</a> to further develop <a href="https://github.com/watermarkhu/OpenSurfaceSim">
-                            OpenSurfaceSim</a>, a simulator package for surface codes. The
+                            Hu</a> to further develop <a href="https://github.com/watermarkhu/qsurface">
+                            Qsurface</a>, a simulator package for surface codes. The
                             grant will improve visualization methods and facilitate the
                             collaboration of an open, modular platform for surface code
                             simulations.
-                        [<a href="https://github.com/watermarkhu/OpenSurfaceSim">github</a>]
+                        [<a href="https://github.com/watermarkhu/qsurface">github</a>]
+                        [<a href="https://qsurface.readthedocs.io/en/latest/index.html">Docs</a>]
                             </p>
                     </li><br>
                         <li>


### PR DESCRIPTION
OpenSurfaceSim has been rebranded to Qsurface. 

This PR updates the grants.html page to reflect this change and adds a link to its documentation. 