### PR TITLE
Fix typos and improve clarity of FAQ copy

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -52,32 +52,31 @@
                     <p class="subtitle leading-arrow"><a name="faq">F.A.Q.</a></p>
 
                     <p>
-                        <b>Q: Can anyone apply?</b> <br>
-                        Yes - any age, any country, no credentials required.<br><br>
+                        <b>Q: Can anyone apply for a grant?</b> <br>
+                        Yes - applicants can be any age and from any country. No credentials are required.<br><br>
 
-                        <b>Q: What type of project qualifies?</b> <br>
-                        Any project that will benefit humanity that leverages or supports quantum technology. Open source and/or open
-                        publication is not a dogmatic requirement - though we would recommend it as a starting point. It is, however,
-                        important to see a rationale for any exceptions (for example if you think it'd be best for the world to
+                        <b>Q: What type of project qualifies for consideration?</b> <br>
+                        We are interested in projects that leverage and support quantum technology to benefit humanity. Projects are not strictly required to 
+		        be open source or open publication - though we recommend it as a starting point. It is, however,
+                        important to provide a rationale in your application for any exceptions (for example, if you think it'd be best for the world to
                         reserve the IP for a company).<br><br>
 
-                        <b>Q: Is there a duration for projects?</b> <br>
-                        We would prefer projects to be completed within 3-6 months. However, if there is a reason that your project
-                        should have a longer time window then include that in your application and we will consider it.<br><br>
+                        <b>Q: Is there a recommended duration for projects?</b> <br>
+                        We prefer projects that can be completed within 3-6 months. However, if there is a reason that your project
+                        should have a longer timeline, then include that in your application and we will consider it.<br><br>
 
-                        <b>Q: What do I get if I win?</b> <br>
-                        We'll give you cash 50% up front. We'll check in with you during the project before sending the second half.
-                        Then we'll do a follow-up phone call and/or email at the end to hear how it went. Payment will come by Paypal or
-                        wire transfer. <br><br>
+                        <b>Q: What happens next if I win?</b> <br>
+                       
+                        We'll publish a list of all the winners on <a href="http://unitary.fund" target="_blank">unitary.fund</a> and you will receive 50% of your grant up front. 
+                        Payment will come by Paypal or wire transfer. Additionally, you can opt in to receive expanded access to cloud-based quantum hardware from Rigetti QCS and
+			IBM Quantum (read our blog post about the IBM Quantum benefits <a href="posts/ibmq_access.html" target="_blank">here</a>). <br><br>
 
-                        Additionally, in your application you can mark if you'd like to receive access to Rigetti QCS and IBMQ (read here our blog post about the IBM Q <a href="posts/ibmq_access.html" target="_blank">benefits</a>). If you
-                        are selected for a grant then you will get this access as well.<br><br>
+			Around the midpoint of your project, we'll check in with you for a progress update before sending the second half of your grant. 
+			Finally, we'll do a follow-up phone call or email upon the completion of your project to hear how it went, and we'll ask 
+			you to submit a short summary that can be posted online. <br><br>
 
-                        We'll publish a list of all the winners on <a href="http://unitary.fund" target="_blank">unitary.fund</a> after
-                        they've been selected. At completion we'll ask you to submit a short summary of the project that can be posted online.
 
-                        During the project, you don't need to make regular reports on your progress (though we'd be happy to hear
-                        from you). <br><br>
+                        
 
                         <b>Q: What happens at the halfway check-in?</b> <br>
                         We'll have a call with you and our advisors where we want to know:
@@ -87,19 +86,18 @@
                                 <li>What lessons have you learned so far?</li>
                                 <li>How can we help with what is coming next?</li>
                             </ul>
-                        This helps evaluate if the project is on-track to merit the second half of grant funding.
+                        This helps us evaluate if the project is on-track to merit the second half of grant funding.
                         <br><br>
 
                         <b>Q: What happens if my project doesn't progress sufficiently in the first half?</b> <br>
                         We expect this to happen sometimes because we fund risky, early stage projects. If all projects
                         succeeded, then we wouldn't be taking on sufficient risk. If this happens with your project, then
-                        the second half won't be funded. Still we'd encourage you to think about failure as a critical
-                        part of learning and exploration. For example, we'll be happy to look at future proposals
-                        from previous grantees who didn't succeed in their first attempt.
-                        We know you'll have learned from the experience.
+                        the second half won't be funded. Still, we'd encourage you to think about failure as a critical
+                        part of learning and exploration. Furthermore, we'll be happy to look at future proposals
+                        from previous grantees who didn't succeed in their first attempt. We know you'll have learned from the experience.
                         <br><br>
 
-                        <b>Q: What are the key dates?</b> <br>
+                        <b>Q: What are the key dates for applying?</b> <br>
                         There are no key dates! Applications are rolling until all grant money has been allocated. <br><br>
 
                         <b>Q: What kind of projects are you looking for?</b> <br>
@@ -117,14 +115,14 @@
                     </ul>
 
                     <p>
-                        …or anything else that feels like it would help make quantum technology useful faster.<br><br>
+                        …or anything else that you feel would accelerate the utility of quantum technology.<br><br>
 
-                        In some cases, in particular for projects involving hardware, we know that our grant likely won't be enough
-                        for the whole project. We're happen for our grant to supplement existing work, though we would like to see
+                        In some cases, particularly for projects involving hardware, we know that our grant likely won't be enough
+                        for the whole project. We're happy for our grant to supplement existing work, though we would like to see
                         justification in your application for why the project could use our support.<br><br>
 
                         <b>Q: Do you fund projects that are contributions to existing open source packages and not just stand alone projects?</b> <br>
-                        Yes! In many cases contributing to an existing project/package will help your work have a lot more impact. We often have
+                        Yes! In many cases, contributing to an existing project/package will help your work have a lot more impact. We have often
                         recommended this approach to applicants.<br><br>
 
                         <b>Q: How will you select the winners?</b> <br>
@@ -132,13 +130,13 @@
                         attention to projects that seem like they won't get funded another way. <br><br>
 
                         <b>Q: What are project funds often used for?</b> <br>
-                        In your application, we ask how you plan to use the funds. Each project is different and we encourage creative suggestions for how to make best use of the grants. Previous successful grants have used funds for:
+                        In your application, we ask how you plan to use the funds. Each project is different and we encourage creative suggestions for how to best make use of the grants. Previous successful grants have used funds for:
                     </p>
                     <ul>
                         <li>developer or researcher time</li>
                         <li>hardware or software licenses</li>
                         <li>publication or distribution costs</li>
-                        <li>hosting and compute resources</li>
+                        <li>hosting and computing resources</li>
                         <li>contributions to open source tools used by the project</li>
                         <li>travel expenses</li>
                     </ul>
@@ -148,12 +146,12 @@
                         with your employer. <br><br>
 
                         <b>Q: Can teams apply?</b> <br>
-                        Yes. Multiple people can apply together as a team. Please fill out a single application, but provide background
-                        information for each person in the team. You should designate a lead person to coordinate the application as
-                        well as receive and distribute/spend the money. <br><br>
+                        Yes. Multiple people can apply together as a team. Please fill out a single application and provide background
+                        information for each person on the team. You should designate a lead person to coordinate the application, as
+                        well as to receive and distribute the money. <br><br>
 
                         <b>Q: Can I apply multiple times?</b> <br>
-                        Yes, you can apply as often as you like. You can win multiple times and we will consider repeat funding to
+                        Yes, you can apply as often as you like. You can win multiple times, and we will consider repeat funding to
                         continue to grow a project to the next level.<br><br>
 
                         <b>Q: I love this idea and I want to help! Can I provide additional funding, datasets, mentorship, or help
@@ -165,12 +163,12 @@
                         The money is a gift. It's not an equity investment or loan, and we won't own any of your intellectual property.
                         Our only request is that you think about how to pay it forward to others.<br><br>
 
-                        <b>Q: How long should I expect a reply?</b> <br>
+                        <b>Q: How long after applying should I expect a reply?</b> <br>
                         We aim to get back to applicants within two weeks.<br><br>
 
                         <b>Q: Are applications private?</b> <br>
                         Yes. Applications are only reviewed by the Unitary Fund team and
-                        advisors and are kept confidential.<br><br>
+                        advisors. They are kept confidential.<br><br>
 
                         <b>Q: Where did you get the idea to do this?</b> <br>
                         This program is inspired by, and directly borrows from


### PR DESCRIPTION
I initially forked this to fix a typo on the FAQ page, but I couldn't resist taking a crack at doing a full edit. The changes I made are intended to improve the clarity of the page overall. I mostly focused on areas where I found the phrasing to be awkward, vague, or wordy. I tried to keep as much of the original copy as possible and maintain the approachable tone. My hope is that the improved clarity might help increase accessibility, especially for those whose first language is not English.

I'm happy to incorporate any feedback or suggestions! 
