### PR TITLE
Update Marta CT and add arXiv link

### DIFF
--- a/grants.html
+++ b/grants.html
@@ -170,8 +170,8 @@
                             <li>
                                 <img class="grant-image" src="/images/dummy.png" alt="grant" />
                                 <p>
-                                    To Nicola Mosco, to develop <a class="recipient-link" href="https://gitlab.com/homodyne-ct/hct-tools">HomodyneCT</a>, a software package for medical diagnostics that uses a quantum-tomography-inspired technique for
-                                    state reconstruction in order to reduce the radiation dose patients receive.
+                                    To Nicola Mosco, to develop <a class="recipient-link" href="https://gitlab.com/homodyne-ct/MartaCT.jl">Marta CT</a>, a software package in Julia for medical diagnostics that uses a quantum-tomography-inspired technique for
+                                    state reconstruction in order to reduce the radiation dose patients receive. [<a href="https://arxiv.org/abs/2106.12353">arXiv</a>]
                                 </p>
                             </li><br>
 


### PR DESCRIPTION
Update Homodyne CT to point to the repository of Marta CT in Julia for medical diagnostics and add arXiv link. 