### PR TITLE
Large video preview

### DIFF
--- a/talks.html
+++ b/talks.html
@@ -91,7 +91,7 @@
                             <li class="leading-block"><span class="blog-post-date">20 May, 2021 - 12pm EST/5pm
                                 GMT</span>
                                 <h4>Intro to <a href="https://github.com/pasqal-io/Pulser">Pulser</a>: Pulse simulation and design for neutral atoms by Loïc Henriet</h4>
-                                <iframe class="video" src="https://www.youtube-nocookie.com/embed/Y4aM9G21tXk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                                <iframe width="640" height="360" class="video" src="https://www.youtube-nocookie.com/embed/Y4aM9G21tXk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                                 <br>
                                 <details>
                                     <summary>About the talk</summary>
@@ -112,7 +112,7 @@
                             <li class="leading-block"><span class="blog-post-date">18 March, 2021 - 12pm EST/5pm
                                 GMT</span>
                                 <h4>Intro to <a href="http://github.com/tqsd/QuNetSim">QuNetSim</a>: A Software Framework for Quantum Networks by Stephen DiAdamo</h4>
-                                <iframe class="video" src="https://www.youtube-nocookie.com/embed/MmdRLYh1_mI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                                <iframe width="640" height="360" class="video" src="https://www.youtube-nocookie.com/embed/MmdRLYh1_mI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                                 <br>
                                 <br>
                                 <details>
@@ -133,7 +133,7 @@
                             <li class="leading-block"><span class="blog-post-date">28 January, 2021 - 12pm EST/5pm
                                     GMT</span>
                                 <h4>Intro to <a href="http://qutip.org/">QuTiP</a>: A Quantum Toolbox in Python by Shahnawaz Ahmed</h4>
-                                <iframe class="video" src="https://www.youtube-nocookie.com/embed/2tF_4ZJAuYY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                                <iframe width="640" height="360" class="video" src="https://www.youtube-nocookie.com/embed/2tF_4ZJAuYY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                                 <br>
                                 <br>
                                 <details>
@@ -155,7 +155,7 @@
                             <li class="leading-block"><span class="blog-post-date">03 December, 2020 - 12pm EST/5pm
                                     GMT</span>
                                 <h4>Intro to <a href="https://qcor.ornl.gov/">qcor</a>: Extending C++ for Heterogeneous Quantum-Classical Computing by Alex McCaskey</h4>
-                                <iframe class="video" src="https://www.youtube-nocookie.com/embed/GzslhEnHUHI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                                <iframe width="640" height="360" class="video" src="https://www.youtube-nocookie.com/embed/GzslhEnHUHI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                                 <br>
                                 <br>
                                 <details>
@@ -180,7 +180,7 @@
                                     GMT</span>
                                 <h4>Intro to <a href="https://github.com/vm6502q/qrack">qrack</a>: a framework for fast quantum simulation by Daniel Strano</h4>
                                 <!-- <h4><a href="https://www.youtube.com/watch?v=yxyqJDC4SUo" >YouTube Recording</a></h4> -->
-                                <iframe class="video" src="https://www.youtube-nocookie.com/embed/yxyqJDC4SUo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                                <iframe width="640" height="360" class="video" src="https://www.youtube-nocookie.com/embed/yxyqJDC4SUo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                                 <br>
                                 <br>
                                 <details>

--- a/talks.html
+++ b/talks.html
@@ -26,7 +26,7 @@
             font: 14px "Lucida Console", Monaco, monospace;
             width: 100%;
         }
-        
+
         #mce-EMAIL {
             padding: 11px;
             margin: 10px;
@@ -80,10 +80,19 @@
 
                         <p class="subtitle leading-arrow">Upcoming talks</p>
 
+                        There are no upcoming Quantum Software Talks scheduled at the moment. Check the Community Calendar above for the other Unitary Fund events.
+
+
+
+
+                        <p class="subtitle leading-arrow">Previous talks</p>
                         <ul id="seminar-list" style="list-style-type: none;">
+
                             <li class="leading-block"><span class="blog-post-date">20 May, 2021 - 12pm EST/5pm
                                 GMT</span>
                                 <h4>Intro to <a href="https://github.com/pasqal-io/Pulser">Pulser</a>: Pulse simulation and design for neutral atoms by Loïc Henriet</h4>
+                                <iframe class="video" src="https://www.youtube-nocookie.com/embed/Y4aM9G21tXk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                                <br>
                                 <details>
                                     <summary>About the talk</summary>
                                     <p> The manipulation of neutral atoms by light is at the heart of countless scientific discoveries in the field of quantum physics in the last three decades. The level of control that has been achieved at the single particle
@@ -99,10 +108,7 @@
                                     </p>
                                 </details>
                             </li><br>
-                        </ul>
 
-                        <p class="subtitle leading-arrow">Previous talks</p>
-                        <ul id="seminar-list" style="list-style-type: none;">
                             <li class="leading-block"><span class="blog-post-date">18 March, 2021 - 12pm EST/5pm
                                 GMT</span>
                                 <h4>Intro to <a href="http://github.com/tqsd/QuNetSim">QuNetSim</a>: A Software Framework for Quantum Networks by Stephen DiAdamo</h4>
@@ -123,6 +129,7 @@
                                     </p>
                                 </details>
                             </li><br>
+
                             <li class="leading-block"><span class="blog-post-date">28 January, 2021 - 12pm EST/5pm
                                     GMT</span>
                                 <h4>Intro to <a href="http://qutip.org/">QuTiP</a>: A Quantum Toolbox in Python by Shahnawaz Ahmed</h4>


### PR DESCRIPTION
Make the larger video preview embedded. 

Basically from this: 

<img width="832" alt="small embed" src="https://user-images.githubusercontent.com/14573436/123976492-797a3d80-d9be-11eb-8be5-2b67c29e54fd.png">


to this: 
<img width="839" alt="large-yt-embed" src="https://user-images.githubusercontent.com/14573436/123976702-a890af00-d9be-11eb-8551-e7082c993cd5.png">


Besides personal taste, I think this way one may not leave the UF website. 
