### PR TITLE
Fix repeated ampersand in team names list

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
                             <a href="https://github.com/karalekas">Peter
                                 Karalekas</a>,
                             <a href="https://github.com/wrathfulspatula">Daniel
-                                Strano</a>, &
+                                Strano</a>,
                             <a href="https://github.com/vprusso">Vincent
                                 Russo</a>, &
                             <a href="http://willzeng.com/" , target="_blank">Will Zeng</a>.


### PR DESCRIPTION
We have the last _two_ names in the list preceded by an ampersand. Only the last name should be preceded by an ampersand.