### PR TITLE
Add new preprints to research to page

### DIFF
--- a/research.html
+++ b/research.html
@@ -98,6 +98,8 @@
                                 <li class="leading-block"><a href="https://arxiv.org/abs/2105.09902">Pulse-level noisy quantum circuits with QuTiP</a></li><br>
                                 <li class="leading-block"><a href="https://arxiv.org/abs/2104.15044">Pulser: An open-source package for the design of pulse sequences in programmable neutral-atom arrays</a></li><br>
                                 <li class="leading-block"><a href="https://arxiv.org/abs/2112.05821">VAQEM: A Variational Approach to Quantum Error Mitigation</a></li><br>
+                                <li class="leading-block"><a href="https://arxiv.org/abs/2201.11792">Reducing the impact of time-correlated noise on zero-noise extrapolation
+                                </a></li><br>
                             </ul>
                         </p>
                         <p class="subtitle leading-arrow"><a name="research-staff">Unitary Fund staff research</a></p>
@@ -106,6 +108,8 @@
                                 <li class="leading-block"><a href="https://arxiv.org/abs/2101.05710">Symmetries and conserved quantities of boundary time crystals in generalized spin models</a></li><br>
                                 <li class="leading-block"><a href="https://arxiv.org/abs/2104.09811">Exceptional Point and Cross-Relaxation Effect in a Hybrid Quantum System</a></li><br>
                                 <li class="leading-block"><a href="https://arxiv.org/abs/2008.06517">Estimating the gradient and higher-order derivatives on quantum hardware</a></li><br>
+                                <li class="leading-block"><a href="https://arxiv.org/abs/2201.08175">Diagnosing quantum chaos with out-of-time-ordered-correlator quasiprobability in the kicked-top model
+                                </a></li><br>
                             </ul>
                         </p>
                         <p class="subtitle leading-arrow"><a name="research-microgrant">Microgrant-supported research</a></p>


### PR DESCRIPTION
- Add the correlated noise ZNE preprint to the Unitary Labs research, https://arxiv.org/abs/2201.11792
- Add the quantum chaos preprint to other research from UF staff, https://arxiv.org/abs/2201.08175