### PR TITLE
Fix mobile view for Metriq release blog post

### DIFF
--- a/posts/metriq_release.html
+++ b/posts/metriq_release.html
@@ -93,8 +93,8 @@
                                 <div style="text-align: center;">
                                     <iframe
                                         id="video"
-                                        width="560"
-                                        height="315"
+                                        width="100%"
+                                        height="400"
                                         src="https://www.youtube-nocookie.com/embed/tg6Q5fnw2EE?rel=0&amp;controls=0&amp;showinfo=0"
                                         frameborder="0"
                                         allowfullscreen="">
@@ -111,8 +111,8 @@
                                 <div style="text-align: center;">
                                     <iframe
                                         id="video"
-                                        width="560"
-                                        height="315"
+                                        width="100%"
+                                        height="400"
                                         src="https://www.youtube-nocookie.com/embed/uZK6L1wIofM?rel=0&amp;controls=0&amp;showinfo=0"
                                         frameborder="0"
                                         allowfullscreen="">


### PR DESCRIPTION
Will just pointed out to me that the Metriq release blog post doesn't fit mobile screens correctly, in portrait view. At least, if we set the width of the two video iframes to (relative) 100%, instead of a fixed width, then the layout can contract horizontally for mobile portrait view.

The trade-off is that, still on mobile portrait view, the video iframes look slightly too tall, and the partner logos are listed one-at-a-time, vertically. @willzeng I can carry this styling further, if that's unacceptable, but one can at least read this, now, and I think it looks okay.