### PR TITLE
Clean up HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/*
 .DS_Store
+node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# Ignore everything
+/*
+
+# Except html files in the root
+!*.html

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,3 +1,2 @@
 printWidth: 120
-bracketSameLine: true
 semi: false

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,3 @@
+printWidth: 120
+bracketSameLine: true
+semi: false

--- a/blog.html
+++ b/blog.html
@@ -67,128 +67,109 @@
                         <section class="light">
                             <ul style="list-style-type: none;">
                                 <li class="leading-block"><span class="blog-post-date">17 May, 2022</span> <a href="posts/metriq_release.html">Unitary Fund launches Metriq, a platform for community driven quantum benchmarks </a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">11 April, 2022</span> <a href="posts/qutip_2021_annual_report.html">QuTiP 2021 Annual Review</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">6 April, 2022</span> <a href="posts/2022_Q1.html">Unitary Fund Q1 2022 Update: New projects, advisors and supporters!</a>
-                                </li><br>
+                                </li>
 
                                 <li class="leading-block"><span class="blog-post-date">31 March, 2022</span> <a href="posts/2022-agnostiq-sponsor.html">Unitary Fund welcomes Agnostiq as a new Unitary Fund supporting member</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">28 February, 2022</span> <a href="posts/2022_oqupy.html">OQuPy: Open Quantum Systems in Python</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">14 February, 2022</span> <a href="posts/2021.html">Unitary Fund 2021 Annual Report</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">9 February, 2022</span> <a href="posts/vqa_in_qutip.html">Implementing a Variational Quantum Algorithms module in QuTiP</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">1 February, 2022</span> <a href="posts/2021-corporate-members.html">Unitary Fund Announces New Support through New Membership Program</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">25 January, 2022</span> <a href="posts/ambassador_alves_intro.html">Meet the UF Ambassadors - Andre Alves</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">24 January, 2022</span> <a href="posts/pulser_qutip.html">Stay on the pulse of open-source quantum simulation with Pulser and QuTiP</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">21 January, 2022</span> <a href="posts/2022_wittek_prize.html">Celebrating quantum open-source software contributors: Announcing the 2021 Wittek prize winner with QOSF</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">13 January, 2022</span> <a href="posts/quantum_compilers.html">A Bird's-Eye View of Upcoming System-Level Quantum-Classical Compilers</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">10 January, 2022</span> <a href="posts/2021_Q4.html">Unitary Fund Q4 2021 Update: New projects, hires, and open roles!</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">17 November, 2021</span> <a href="posts/krylov.html">A Krylov Approximation Method for Quantum Evolution</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">11 November, 2021</span> <a href="posts/ambassador_wahl_intro.html">Meet the UF Ambassadors – Misty Wahl</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">9 November, 2021</span> <a href="posts/quantumalgorithmsorg.html">Learn how to write new quantum algorithms on quantumalgorithms.org</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">27 October, 2021</span> <a href="posts/mitiq_vqa_performance.html">Improving VQA Performance through Error Mitigation</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">19 October, 2021</span> <a href="posts/uf_ambassadors.html">Announcing the Unitary Fund Ambassador Program and introducing our first Ambassadors</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">13 October, 2021</span> <a href="posts/2021_unitaryhack_results.html">unitaryHACK retrospective: Growing the quantum open source community one commit at a time</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">11 October, 2021</span> <a href="posts/2021_Q3.html">Unitary Fund Q3 2021 Update: New projects, the 2021 Wittek Prize and QuTiP community calls</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">4 October, 2021</span> <a href="posts/braket.html">New support for Mitiq on Amazon Braket</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">23 September, 2021</span> <a href="posts/2021_ieee_workshops.html">Two Workshops Organized in 2021 IEEE Quantum Week: Open Hardware and Intermediate Representations</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">17 September, 2021</span> <a href="posts/interlin-q.html">Microgrant Update: Interlin-q for distributed quantum computing</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">13 September, 2021</span> <a href="posts/2021_wittek_prize.html">Nominations open for the 2021 Wittek Quantum Prize for Open Source Software</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">15 July, 2021</span> <a href="posts/new_version_mitiq_paper.html">A new version of the Mitiq white paper</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">12 July, 2021</span> <a href="posts/qutip_10_years.html">QuTiP's 10-year anniversary</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">7 July, 2021</span> <a href="posts/2021_Q2.html">Unitary Fund Q2 2021 Update: UnitaryHACK, new projects, Mitiq's new features</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">9 April, 2021</span> <a href="posts/2021_Q1.html">Unitary Fund Q1 2021 Update: New projects and a Mitiq release driven by the community</a>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">8 April, 2021</span> <a href="posts/unitaryhack2021.html">Announcing unitaryHACK 2021</a>
                                 </li>
-                                <br>
-
                                 <li class="leading-block"><span class="blog-post-date">5 February, 2021</span> <a href="posts/Q4_2020.html">Unitary Fund Q4 2020 Update: Quantum Software Talks,
                                         Mitiq updates and more grants</a>
                                 </li>
-                                <br>
-
                                 <li class="leading-block"><span class="blog-post-date">1 February, 2021</span> <a href="posts/2020_wittek_prize.html">Celebrating quantum open-source software
                                         contributors: Announcing the 2020 Wittek prize winner with QOSF</a>
                                 </li>
-                                <br>
-
                                 <li class="leading-block"><span class="blog-post-date">22 January, 2021</span> <a href="posts/pasqal.html">Advancing open science with Pasqal's atom-based quantum
                                         processors</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">18 January, 2021</span> <a href="posts/2020.html">Unitary Fund 2020 Annual Report</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">24 November, 2020</span> <a href="posts/ibmq_access.html">Unitary Fund partners with IBM quantum to provide
                                         hardware access to Unitary Fund awardees</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">3 October, 2020</span> <a href="posts/Q3_2020.html">Unitary Fund Q3 2020 Update: Mitiq, new grants and
                                         supported projects</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">10 September, 2020</span> <a href="posts/mitiq.html">Introducing Mitiq, an open-source software package for
                                         quantum error mitigation</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">21 July, 2020</span> <a href="posts/high_school_resources.html">Quantum Computing Resources for High
                                         School Students</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">7 July, 2020</span> <a href="posts/Q2_2020.html">Unitary Fund Q2 2020 Update: new advisory board and
                                         new grants</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">22 June, 2020</span> <a href="posts/advisory_board.html">Unitary Fund Welcomes New Advisory Board</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">2 April, 2020</span> <a href="posts/Q1_2020.html">Unitary Fund Q1 2020 Update: new team members and new
                                         grants</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">24 March, 2020</span> <a href="posts/unitary_labs_intro.html">Introducing the Technical Team: Unitary
                                         Labs</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">21 November, 2019</span> <a href="https://medium.com/@wjzeng/unitary-fund-launches-new-quantum-micro-grant-program-and-five-year-research-collaboration-funded-7f6f2d479758">
                                         Unitary Fund Launches New Quantum Micro-Grant Program and Five-Year Research
                                         Collaboration funded by
                                         the DOE</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">7 February, 2019</span> <a href="https://medium.com/@wjzeng/open-source-quantum-software-at-fosdem-19-4de0f70039f0">
                                         Open source quantum software at FOSDEM 19</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">16 October, 2018</span> <a href="https://medium.com/@wjzeng/unitary-fund-the-first-quarter-540d3c66188e">
                                         Unitary Fund: The first quarter</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">24 June, 2018</span> <a href="https://medium.com/@wjzeng/the-unitary-fund-get-2-000-for-your-open-source-quantum-computing-project-d4b4c76ba177">
                                         The Unitary Fund: Get $2,000 for your open source quantum computing project</a>
                                 </li>

--- a/blog.html
+++ b/blog.html
@@ -280,7 +280,8 @@
                   <li class="leading-block">
                     <span class="blog-post-date">21 November, 2019</span>
                     <a
-                      href="https://medium.com/@wjzeng/unitary-fund-launches-new-quantum-micro-grant-program-and-five-year-research-collaboration-funded-7f6f2d479758">
+                      href="https://medium.com/@wjzeng/unitary-fund-launches-new-quantum-micro-grant-program-and-five-year-research-collaboration-funded-7f6f2d479758"
+                    >
                       Unitary Fund Launches New Quantum Micro-Grant Program and Five-Year Research Collaboration funded
                       by the DOE</a
                     >
@@ -300,7 +301,8 @@
                   <li class="leading-block">
                     <span class="blog-post-date">24 June, 2018</span>
                     <a
-                      href="https://medium.com/@wjzeng/the-unitary-fund-get-2-000-for-your-open-source-quantum-computing-project-d4b4c76ba177">
+                      href="https://medium.com/@wjzeng/the-unitary-fund-get-2-000-for-your-open-source-quantum-computing-project-d4b4c76ba177"
+                    >
                       The Unitary Fund: Get $2,000 for your open source quantum computing project</a
                     >
                   </li>

--- a/blog.html
+++ b/blog.html
@@ -1,256 +1,398 @@
 <!DOCTYPE html>
 
 <html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
 
     <title>Unitary Fund</title>
     <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="style.css">
-    <link rel="stylesheet" type="text/css" href="hamburgers.min.css">
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
-    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-        #mc_embed_signup {
-            background: #fff;
-            clear: left;
-            font: 14px "Lucida Console", Monaco, monospace;
-            width: 100%;
-        }
+      #mc_embed_signup {
+        background: #fff;
+        clear: left;
+        font: 14px "Lucida Console", Monaco, monospace;
+        width: 100%;
+      }
 
-        #mce-EMAIL {
-            padding: 11px;
-            margin: 10px;
-        }
+      #mce-EMAIL {
+        padding: 11px;
+        margin: 10px;
+      }
     </style>
 
     <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
+      window.dataLayer = window.dataLayer || []
 
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-        gtag('config', 'UA-19932157-4');
+      gtag("config", "UA-19932157-4")
     </script>
-</head>
+  </head>
 
-<body>
+  <body>
     <div class="layout">
-        <main id="content" class="content">
-            <section class="heavy">
-                <div class="container">
-                    <div class="col-3">
-                        <div class="hero">
-                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
-                            <p class="tagline"><b>Because evolution is
-                        <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b>.</p>
-                            <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
-                            <span class="hamburger-box">
-                              <span class="hamburger-inner"></span>
-                            </span>
-                        </button>
-                        </div>
-                        <p class="leading-arrow"> <b>Unitary Fund</b> is a non-profit working to create a quantum technology ecosystem that benefits the most people.
-                        </p>
-                        <section class="light">
-                            <ul style="list-style-type: none;">
-                                <li class="leading-block"><span class="blog-post-date">17 May, 2022</span> <a href="posts/metriq_release.html">Unitary Fund launches Metriq, a platform for community driven quantum benchmarks </a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">11 April, 2022</span> <a href="posts/qutip_2021_annual_report.html">QuTiP 2021 Annual Review</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">6 April, 2022</span> <a href="posts/2022_Q1.html">Unitary Fund Q1 2022 Update: New projects, advisors and supporters!</a>
-                                </li>
+      <main id="content" class="content">
+        <section class="heavy">
+          <div class="container">
+            <div class="col-3">
+              <div class="hero">
+                <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
+                <p class="tagline">
+                  <b
+                    >Because evolution is
+                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b
+                  >.
+                </p>
+                <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
+                  <span class="hamburger-box">
+                    <span class="hamburger-inner"></span>
+                  </span>
+                </button>
+              </div>
+              <p class="leading-arrow">
+                <b>Unitary Fund</b> is a non-profit working to create a quantum technology ecosystem that benefits the
+                most people.
+              </p>
+              <section class="light">
+                <ul style="list-style-type: none">
+                  <li class="leading-block">
+                    <span class="blog-post-date">17 May, 2022</span>
+                    <a href="posts/metriq_release.html"
+                      >Unitary Fund launches Metriq, a platform for community driven quantum benchmarks
+                    </a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">11 April, 2022</span>
+                    <a href="posts/qutip_2021_annual_report.html">QuTiP 2021 Annual Review</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">6 April, 2022</span>
+                    <a href="posts/2022_Q1.html">Unitary Fund Q1 2022 Update: New projects, advisors and supporters!</a>
+                  </li>
 
-                                <li class="leading-block"><span class="blog-post-date">31 March, 2022</span> <a href="posts/2022-agnostiq-sponsor.html">Unitary Fund welcomes Agnostiq as a new Unitary Fund supporting member</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">28 February, 2022</span> <a href="posts/2022_oqupy.html">OQuPy: Open Quantum Systems in Python</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">14 February, 2022</span> <a href="posts/2021.html">Unitary Fund 2021 Annual Report</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">9 February, 2022</span> <a href="posts/vqa_in_qutip.html">Implementing a Variational Quantum Algorithms module in QuTiP</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">1 February, 2022</span> <a href="posts/2021-corporate-members.html">Unitary Fund Announces New Support through New Membership Program</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">25 January, 2022</span> <a href="posts/ambassador_alves_intro.html">Meet the UF Ambassadors - Andre Alves</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">24 January, 2022</span> <a href="posts/pulser_qutip.html">Stay on the pulse of open-source quantum simulation with Pulser and QuTiP</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">21 January, 2022</span> <a href="posts/2022_wittek_prize.html">Celebrating quantum open-source software contributors: Announcing the 2021 Wittek prize winner with QOSF</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">13 January, 2022</span> <a href="posts/quantum_compilers.html">A Bird's-Eye View of Upcoming System-Level Quantum-Classical Compilers</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">10 January, 2022</span> <a href="posts/2021_Q4.html">Unitary Fund Q4 2021 Update: New projects, hires, and open roles!</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">17 November, 2021</span> <a href="posts/krylov.html">A Krylov Approximation Method for Quantum Evolution</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">11 November, 2021</span> <a href="posts/ambassador_wahl_intro.html">Meet the UF Ambassadors – Misty Wahl</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">9 November, 2021</span> <a href="posts/quantumalgorithmsorg.html">Learn how to write new quantum algorithms on quantumalgorithms.org</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">27 October, 2021</span> <a href="posts/mitiq_vqa_performance.html">Improving VQA Performance through Error Mitigation</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">19 October, 2021</span> <a href="posts/uf_ambassadors.html">Announcing the Unitary Fund Ambassador Program and introducing our first Ambassadors</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">13 October, 2021</span> <a href="posts/2021_unitaryhack_results.html">unitaryHACK retrospective: Growing the quantum open source community one commit at a time</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">11 October, 2021</span> <a href="posts/2021_Q3.html">Unitary Fund Q3 2021 Update: New projects, the 2021 Wittek Prize and QuTiP community calls</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">4 October, 2021</span> <a href="posts/braket.html">New support for Mitiq on Amazon Braket</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">23 September, 2021</span> <a href="posts/2021_ieee_workshops.html">Two Workshops Organized in 2021 IEEE Quantum Week: Open Hardware and Intermediate Representations</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">17 September, 2021</span> <a href="posts/interlin-q.html">Microgrant Update: Interlin-q for distributed quantum computing</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">13 September, 2021</span> <a href="posts/2021_wittek_prize.html">Nominations open for the 2021 Wittek Quantum Prize for Open Source Software</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">15 July, 2021</span> <a href="posts/new_version_mitiq_paper.html">A new version of the Mitiq white paper</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">12 July, 2021</span> <a href="posts/qutip_10_years.html">QuTiP's 10-year anniversary</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">7 July, 2021</span> <a href="posts/2021_Q2.html">Unitary Fund Q2 2021 Update: UnitaryHACK, new projects, Mitiq's new features</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">9 April, 2021</span> <a href="posts/2021_Q1.html">Unitary Fund Q1 2021 Update: New projects and a Mitiq release driven by the community</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">8 April, 2021</span> <a href="posts/unitaryhack2021.html">Announcing unitaryHACK 2021</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">5 February, 2021</span> <a href="posts/Q4_2020.html">Unitary Fund Q4 2020 Update: Quantum Software Talks,
-                                        Mitiq updates and more grants</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">1 February, 2021</span> <a href="posts/2020_wittek_prize.html">Celebrating quantum open-source software
-                                        contributors: Announcing the 2020 Wittek prize winner with QOSF</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">22 January, 2021</span> <a href="posts/pasqal.html">Advancing open science with Pasqal's atom-based quantum
-                                        processors</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">18 January, 2021</span> <a href="posts/2020.html">Unitary Fund 2020 Annual Report</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">24 November, 2020</span> <a href="posts/ibmq_access.html">Unitary Fund partners with IBM quantum to provide
-                                        hardware access to Unitary Fund awardees</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">3 October, 2020</span> <a href="posts/Q3_2020.html">Unitary Fund Q3 2020 Update: Mitiq, new grants and
-                                        supported projects</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">10 September, 2020</span> <a href="posts/mitiq.html">Introducing Mitiq, an open-source software package for
-                                        quantum error mitigation</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">21 July, 2020</span> <a href="posts/high_school_resources.html">Quantum Computing Resources for High
-                                        School Students</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">7 July, 2020</span> <a href="posts/Q2_2020.html">Unitary Fund Q2 2020 Update: new advisory board and
-                                        new grants</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">22 June, 2020</span> <a href="posts/advisory_board.html">Unitary Fund Welcomes New Advisory Board</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">2 April, 2020</span> <a href="posts/Q1_2020.html">Unitary Fund Q1 2020 Update: new team members and new
-                                        grants</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">24 March, 2020</span> <a href="posts/unitary_labs_intro.html">Introducing the Technical Team: Unitary
-                                        Labs</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">21 November, 2019</span> <a href="https://medium.com/@wjzeng/unitary-fund-launches-new-quantum-micro-grant-program-and-five-year-research-collaboration-funded-7f6f2d479758">
-                                        Unitary Fund Launches New Quantum Micro-Grant Program and Five-Year Research
-                                        Collaboration funded by
-                                        the DOE</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">7 February, 2019</span> <a href="https://medium.com/@wjzeng/open-source-quantum-software-at-fosdem-19-4de0f70039f0">
-                                        Open source quantum software at FOSDEM 19</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">16 October, 2018</span> <a href="https://medium.com/@wjzeng/unitary-fund-the-first-quarter-540d3c66188e">
-                                        Unitary Fund: The first quarter</a>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">24 June, 2018</span> <a href="https://medium.com/@wjzeng/the-unitary-fund-get-2-000-for-your-open-source-quantum-computing-project-d4b4c76ba177">
-                                        The Unitary Fund: Get $2,000 for your open source quantum computing project</a>
-                                </li>
-                            </ul>
+                  <li class="leading-block">
+                    <span class="blog-post-date">31 March, 2022</span>
+                    <a href="posts/2022-agnostiq-sponsor.html"
+                      >Unitary Fund welcomes Agnostiq as a new Unitary Fund supporting member</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">28 February, 2022</span>
+                    <a href="posts/2022_oqupy.html">OQuPy: Open Quantum Systems in Python</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">14 February, 2022</span>
+                    <a href="posts/2021.html">Unitary Fund 2021 Annual Report</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">9 February, 2022</span>
+                    <a href="posts/vqa_in_qutip.html">Implementing a Variational Quantum Algorithms module in QuTiP</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">1 February, 2022</span>
+                    <a href="posts/2021-corporate-members.html"
+                      >Unitary Fund Announces New Support through New Membership Program</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">25 January, 2022</span>
+                    <a href="posts/ambassador_alves_intro.html">Meet the UF Ambassadors - Andre Alves</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">24 January, 2022</span>
+                    <a href="posts/pulser_qutip.html"
+                      >Stay on the pulse of open-source quantum simulation with Pulser and QuTiP</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">21 January, 2022</span>
+                    <a href="posts/2022_wittek_prize.html"
+                      >Celebrating quantum open-source software contributors: Announcing the 2021 Wittek prize winner
+                      with QOSF</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">13 January, 2022</span>
+                    <a href="posts/quantum_compilers.html"
+                      >A Bird's-Eye View of Upcoming System-Level Quantum-Classical Compilers</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">10 January, 2022</span>
+                    <a href="posts/2021_Q4.html">Unitary Fund Q4 2021 Update: New projects, hires, and open roles!</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">17 November, 2021</span>
+                    <a href="posts/krylov.html">A Krylov Approximation Method for Quantum Evolution</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">11 November, 2021</span>
+                    <a href="posts/ambassador_wahl_intro.html">Meet the UF Ambassadors – Misty Wahl</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">9 November, 2021</span>
+                    <a href="posts/quantumalgorithmsorg.html"
+                      >Learn how to write new quantum algorithms on quantumalgorithms.org</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">27 October, 2021</span>
+                    <a href="posts/mitiq_vqa_performance.html">Improving VQA Performance through Error Mitigation</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">19 October, 2021</span>
+                    <a href="posts/uf_ambassadors.html"
+                      >Announcing the Unitary Fund Ambassador Program and introducing our first Ambassadors</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">13 October, 2021</span>
+                    <a href="posts/2021_unitaryhack_results.html"
+                      >unitaryHACK retrospective: Growing the quantum open source community one commit at a time</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">11 October, 2021</span>
+                    <a href="posts/2021_Q3.html"
+                      >Unitary Fund Q3 2021 Update: New projects, the 2021 Wittek Prize and QuTiP community calls</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">4 October, 2021</span>
+                    <a href="posts/braket.html">New support for Mitiq on Amazon Braket</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">23 September, 2021</span>
+                    <a href="posts/2021_ieee_workshops.html"
+                      >Two Workshops Organized in 2021 IEEE Quantum Week: Open Hardware and Intermediate
+                      Representations</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">17 September, 2021</span>
+                    <a href="posts/interlin-q.html">Microgrant Update: Interlin-q for distributed quantum computing</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">13 September, 2021</span>
+                    <a href="posts/2021_wittek_prize.html"
+                      >Nominations open for the 2021 Wittek Quantum Prize for Open Source Software</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">15 July, 2021</span>
+                    <a href="posts/new_version_mitiq_paper.html">A new version of the Mitiq white paper</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">12 July, 2021</span>
+                    <a href="posts/qutip_10_years.html">QuTiP's 10-year anniversary</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">7 July, 2021</span>
+                    <a href="posts/2021_Q2.html"
+                      >Unitary Fund Q2 2021 Update: UnitaryHACK, new projects, Mitiq's new features</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">9 April, 2021</span>
+                    <a href="posts/2021_Q1.html"
+                      >Unitary Fund Q1 2021 Update: New projects and a Mitiq release driven by the community</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">8 April, 2021</span>
+                    <a href="posts/unitaryhack2021.html">Announcing unitaryHACK 2021</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">5 February, 2021</span>
+                    <a href="posts/Q4_2020.html"
+                      >Unitary Fund Q4 2020 Update: Quantum Software Talks, Mitiq updates and more grants</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">1 February, 2021</span>
+                    <a href="posts/2020_wittek_prize.html"
+                      >Celebrating quantum open-source software contributors: Announcing the 2020 Wittek prize winner
+                      with QOSF</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">22 January, 2021</span>
+                    <a href="posts/pasqal.html">Advancing open science with Pasqal's atom-based quantum processors</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">18 January, 2021</span>
+                    <a href="posts/2020.html">Unitary Fund 2020 Annual Report</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">24 November, 2020</span>
+                    <a href="posts/ibmq_access.html"
+                      >Unitary Fund partners with IBM quantum to provide hardware access to Unitary Fund awardees</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">3 October, 2020</span>
+                    <a href="posts/Q3_2020.html"
+                      >Unitary Fund Q3 2020 Update: Mitiq, new grants and supported projects</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">10 September, 2020</span>
+                    <a href="posts/mitiq.html"
+                      >Introducing Mitiq, an open-source software package for quantum error mitigation</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">21 July, 2020</span>
+                    <a href="posts/high_school_resources.html">Quantum Computing Resources for High School Students</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">7 July, 2020</span>
+                    <a href="posts/Q2_2020.html">Unitary Fund Q2 2020 Update: new advisory board and new grants</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">22 June, 2020</span>
+                    <a href="posts/advisory_board.html">Unitary Fund Welcomes New Advisory Board</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">2 April, 2020</span>
+                    <a href="posts/Q1_2020.html">Unitary Fund Q1 2020 Update: new team members and new grants</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">24 March, 2020</span>
+                    <a href="posts/unitary_labs_intro.html">Introducing the Technical Team: Unitary Labs</a>
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">21 November, 2019</span>
+                    <a
+                      href="https://medium.com/@wjzeng/unitary-fund-launches-new-quantum-micro-grant-program-and-five-year-research-collaboration-funded-7f6f2d479758">
+                      Unitary Fund Launches New Quantum Micro-Grant Program and Five-Year Research Collaboration funded
+                      by the DOE</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">7 February, 2019</span>
+                    <a href="https://medium.com/@wjzeng/open-source-quantum-software-at-fosdem-19-4de0f70039f0">
+                      Open source quantum software at FOSDEM 19</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">16 October, 2018</span>
+                    <a href="https://medium.com/@wjzeng/unitary-fund-the-first-quarter-540d3c66188e">
+                      Unitary Fund: The first quarter</a
+                    >
+                  </li>
+                  <li class="leading-block">
+                    <span class="blog-post-date">24 June, 2018</span>
+                    <a
+                      href="https://medium.com/@wjzeng/the-unitary-fund-get-2-000-for-your-open-source-quantum-computing-project-d4b4c76ba177">
+                      The Unitary Fund: Get $2,000 for your open source quantum computing project</a
+                    >
+                  </li>
+                </ul>
 
-                            <br>
-
-
-                        </section>
-                        <footer class="footer leading-arrow light-arrow">
-                            This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br> If you have suggestions for changes then please open up a pull request!
-                            <br>
-                            <br>
-                            <table>
-                                <tr>
-                                    <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                                class="fa fa-twitter"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                                class="fa fa-twitch"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                                class="fa fa-youtube"></i></a></th>
-                                    <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                                class="fab fa-discord"></i></a></th>
-                                </tr>
-                            </table> &copy;2020 Unitary Fund
-                        </footer>
-                    </div>
-                    <div class="col-1" id="menu-container">
-                        <table style="width:auto; margin-right:0px; margin-left: auto;">
-                            <tr>
-                                <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                            class="fa fa-twitter"></i></a></th>
-                                <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                            class="fa fa-twitch"></i></a></th>
-                                <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                            class="fa fa-youtube"></i></a></th>
-                                <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                            class="fab fa-discord"></i></a></th>
-                            </tr>
-                        </table>
-                        <p class="light" id="menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html" class="active">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                    <div id="mobile-menu-container">
-                        <p class="light" id="mobile-menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html" class="active">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                </div>
-            </section>
-        </main>
+                <br />
+              </section>
+              <footer class="footer leading-arrow light-arrow">
+                This website is hosted on
+                <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>.
+                <br />
+                If you have suggestions for changes then please open up a pull request!
+                <br />
+                <br />
+                <table>
+                  <tr>
+                    <th style="text-align: right">
+                      <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"
+                        ><i class="fa fa-youtube"></i
+                      ></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                    </th>
+                  </tr>
+                </table>
+                &copy;2020 Unitary Fund
+              </footer>
+            </div>
+            <div class="col-1" id="menu-container">
+              <table style="width: auto; margin-right: 0px; margin-left: auto">
+                <tr>
+                  <th style="text-align: right">
+                    <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                  </th>
+                </tr>
+              </table>
+              <p class="light" id="menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html" class="active">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+            <div id="mobile-menu-container">
+              <p class="light" id="mobile-menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html" class="active">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
     <script>
-        var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
-        mobileMenuContainer = document.querySelector("#mobile-menu-container");
-        mobileMenuIcon.addEventListener("click", function() {
-            mobileMenuIcon.classList.toggle("is-active");
-            mobileMenuContainer.classList.toggle("active");
-        });
+      var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
+      mobileMenuContainer = document.querySelector("#mobile-menu-container")
+      mobileMenuIcon.addEventListener("click", function () {
+        mobileMenuIcon.classList.toggle("is-active")
+        mobileMenuContainer.classList.toggle("active")
+      })
     </script>
-</body>
-
+  </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 
 <html>
-<script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -32,6 +31,7 @@
         }
     </style>
 
+    <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>

--- a/blog.html
+++ b/blog.html
@@ -53,7 +53,7 @@
                 <div class="container">
                     <div class="col-3">
                         <div class="hero">
-                            <a href="/"><img src="/logos/logov3.svg" alt="Unitary Fund" /></a>
+                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
                             <p class="tagline"><b>Because evolution is
                         <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b>.</p>
                             <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">

--- a/blog.html
+++ b/blog.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/blog.html
+++ b/blog.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
-    <style type="text/css">
+    <style>
       #mc_embed_signup {
         background: #fff;
         clear: left;

--- a/careers.html
+++ b/careers.html
@@ -53,7 +53,7 @@
                 <div class="container">
                     <div class="col-3">
                         <div class="hero">
-                            <a href="/"><img src="/logos/logov3.svg" alt="Unitary Fund" /></a>
+                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
                             <p class="tagline"><b>Because evolution is
                                     <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
                                         target="_blank">unitary</a></b>.</p>

--- a/careers.html
+++ b/careers.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 
 <html>
-<script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -32,6 +31,7 @@
         }
     </style>
 
+    <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>

--- a/careers.html
+++ b/careers.html
@@ -1,152 +1,170 @@
 <!DOCTYPE html>
 
 <html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
 
     <title>Unitary Fund</title>
     <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="style.css">
-    <link rel="stylesheet" type="text/css" href="hamburgers.min.css">
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
-    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-        #mc_embed_signup {
-            background: #fff;
-            clear: left;
-            font: 14px "Lucida Console", Monaco, monospace;
-            width: 100%;
-        }
-        
-        #mce-EMAIL {
-            padding: 11px;
-            margin: 10px;
-        }
+      #mc_embed_signup {
+        background: #fff;
+        clear: left;
+        font: 14px "Lucida Console", Monaco, monospace;
+        width: 100%;
+      }
+
+      #mce-EMAIL {
+        padding: 11px;
+        margin: 10px;
+      }
     </style>
 
     <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
+      window.dataLayer = window.dataLayer || []
 
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-        gtag('config', 'UA-19932157-4');
+      gtag("config", "UA-19932157-4")
     </script>
-</head>
+  </head>
 
-<body>
+  <body>
     <div class="layout">
-        <main id="content" class="content">
-            <section class="heavy">
-                <div class="container">
-                    <div class="col-3">
-                        <div class="hero">
-                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
-                            <p class="tagline"><b>Because evolution is
-                                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
-                                        target="_blank">unitary</a></b>.</p>
-                            <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
-                                <span class="hamburger-box">
-                                    <span class="hamburger-inner"></span>
-                                </span>
-                            </button>
-                        </div>
+      <main id="content" class="content">
+        <section class="heavy">
+          <div class="container">
+            <div class="col-3">
+              <div class="hero">
+                <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
+                <p class="tagline">
+                  <b
+                    >Because evolution is
+                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b
+                  >.
+                </p>
+                <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
+                  <span class="hamburger-box">
+                    <span class="hamburger-inner"></span>
+                  </span>
+                </button>
+              </div>
 
-                        <p class="subtitle leading-arrow">Want to help build the open quantum technology ecosystem?</p>
-                        <b>Unitary Fund</b> is always looking for new team members who can help us make quantum tech that benefits the most people. See our open listings below!
+              <p class="subtitle leading-arrow">Want to help build the open quantum technology ecosystem?</p>
+              <b>Unitary Fund</b> is always looking for new team members who can help us make quantum tech that benefits
+              the most people. See our open listings below!
 
-                        <h3> There are no currently open positions</h3>
-  
+              <h3>There are no currently open positions</h3>
 
-                        <br> If you don't see a role that's a fit, but think you can help us in our mission, then email us at
-                        <a href="mailto:info@unitary.fund">info@unitary.fund</a>.
-                        <br>
+              <br />
+              If you don't see a role that's a fit, but think you can help us in our mission, then email us at
+              <a href="mailto:info@unitary.fund">info@unitary.fund</a>.
+              <br />
 
-                        <footer class="footer leading-arrow light-arrow">
-                            This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
-                                        of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request!
-                            <br>
-                            <br>
-                            <table>
-                                <tr>
-                                    <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                                        class="fa fa-twitter"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                                        class="fa fa-twitch"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                                        class="fa fa-youtube"></i></a></th>
-                                    <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                                        class="fab fa-discord"></i></a></th>
-                                </tr>
-                            </table> &copy;2020 Unitary Fund
-                        </footer>
-                    </div>
-                    <div class="col-1" id="menu-container">
-                        <table style="width:auto; margin-right:0px; margin-left: auto;">
-                            <tr>
-                                <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                            class="fa fa-twitter"></i></a></th>
-                                <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                            class="fa fa-twitch"></i></a></th>
-                                <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                            class="fa fa-youtube"></i></a></th>
-                                <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                            class="fab fa-discord"></i></a></th>
-                            </tr>
-                        </table>
-                        <p class="light" id="menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html" class="active">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                    <div id="mobile-menu-container">
-                        <p class="light" id="mobile-menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html" class="active">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                </div>
-            </section>
-        </main>
+              <footer class="footer leading-arrow light-arrow">
+                This website is hosted on
+                <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community
+                follows this
+                <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a
+                >. <br />
+                <br />
+                If you have suggestions for changes then please open up a pull request!
+                <br />
+                <br />
+                <table>
+                  <tr>
+                    <th style="text-align: right">
+                      <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"
+                        ><i class="fa fa-youtube"></i
+                      ></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                    </th>
+                  </tr>
+                </table>
+                &copy;2020 Unitary Fund
+              </footer>
+            </div>
+            <div class="col-1" id="menu-container">
+              <table style="width: auto; margin-right: 0px; margin-left: auto">
+                <tr>
+                  <th style="text-align: right">
+                    <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                  </th>
+                </tr>
+              </table>
+              <p class="light" id="menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html" class="active">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+            <div id="mobile-menu-container">
+              <p class="light" id="mobile-menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html" class="active">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
     <script>
-        var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
-        mobileMenuContainer = document.querySelector("#mobile-menu-container");
-        mobileMenuIcon.addEventListener("click", function() {
-            mobileMenuIcon.classList.toggle("is-active");
-            mobileMenuContainer.classList.toggle("active");
-        });
+      var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
+      mobileMenuContainer = document.querySelector("#mobile-menu-container")
+      mobileMenuIcon.addEventListener("click", function () {
+        mobileMenuIcon.classList.toggle("is-active")
+        mobileMenuContainer.classList.toggle("active")
+      })
     </script>
-</body>
-
+  </body>
 </html>

--- a/careers.html
+++ b/careers.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/careers.html
+++ b/careers.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
-    <style type="text/css">
+    <style>
       #mc_embed_signup {
         background: #fff;
         clear: left;

--- a/donate.html
+++ b/donate.html
@@ -1,156 +1,179 @@
 <!DOCTYPE html>
 
 <html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
 
     <title>Unitary Fund</title>
     <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="style.css">
-    <link rel="stylesheet" type="text/css" href="hamburgers.min.css">
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
-    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-        #mc_embed_signup {
-            background: #fff;
-            clear: left;
-            font: 14px "Lucida Console", Monaco, monospace;
-            width: 100%;
-        }
-        
-        #mce-EMAIL {
-            padding: 11px;
-            margin: 10px;
-        }
+      #mc_embed_signup {
+        background: #fff;
+        clear: left;
+        font: 14px "Lucida Console", Monaco, monospace;
+        width: 100%;
+      }
+
+      #mce-EMAIL {
+        padding: 11px;
+        margin: 10px;
+      }
     </style>
 
     <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
+      window.dataLayer = window.dataLayer || []
 
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-        gtag('config', 'UA-19932157-4');
+      gtag("config", "UA-19932157-4")
     </script>
-</head>
+  </head>
 
-<body>
+  <body>
     <div class="layout">
-        <main id="content" class="content">
-            <section class="heavy">
-                <div class="container">
-                    <div class="col-3">
-                        <div class="hero">
-                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
-                            <p class="tagline"><b>Because evolution is
-                                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
-                                        target="_blank">unitary</a></b>.</p>
-                            <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
-                                <span class="hamburger-box">
-                                    <span class="hamburger-inner"></span>
-                                </span>
-                            </button>
-                        </div>
+      <main id="content" class="content">
+        <section class="heavy">
+          <div class="container">
+            <div class="col-3">
+              <div class="hero">
+                <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
+                <p class="tagline">
+                  <b
+                    >Because evolution is
+                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b
+                  >.
+                </p>
+                <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
+                  <span class="hamburger-box">
+                    <span class="hamburger-inner"></span>
+                  </span>
+                </button>
+              </div>
 
-                        <p class="subtitle leading-arrow">Help support open source quantum software with the Unitary Fund
-                        </p>
-                        <b>Unitary Fund</b> is a 501(c)(3) non-profit working to create a quantum technology ecosystem that benefits the most people. Help to strengthen the open source tools that will enable quantum computing by becoming a champion today!
-                        <br>
-                        <br> You can also represent the Unitary Fund by buying some of our <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>!
-                        <br>
-                        <br>
-                        <!-- INSERT PAYPAL HTML HERE -->
+              <p class="subtitle leading-arrow">Help support open source quantum software with the Unitary Fund</p>
+              <b>Unitary Fund</b> is a 501(c)(3) non-profit working to create a quantum technology ecosystem that
+              benefits the most people. Help to strengthen the open source tools that will enable quantum computing by
+              becoming a champion today!
+              <br />
+              <br />
+              You can also represent the Unitary Fund by buying some of our
+              <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>!
+              <br />
+              <br />
+              <!-- INSERT PAYPAL HTML HERE -->
 
-                        <div style="display: block; margin-left: auto; margin-right: auto; width: 50%;">
-                            <a href="https://www.paypal.com/donate/?cmd=_s-xclick&hosted_button_id=NYN7D2ADDYQ78&source=url"><img src="images/donate-button.png" alt="donate button"></a>
-                            <br> via PayPal
-                        </div>
+              <div style="display: block; margin-left: auto; margin-right: auto; width: 50%">
+                <a href="https://www.paypal.com/donate/?cmd=_s-xclick&hosted_button_id=NYN7D2ADDYQ78&source=url"
+                  ><img src="images/donate-button.png" alt="donate button"
+                /></a>
+                <br />
+                via PayPal
+              </div>
 
-                        <footer class="footer leading-arrow light-arrow">
-                            This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
-                                of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request!
-                            <br>
-                            <br>
-                            <table>
-                                <tr>
-                                    <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                                class="fa fa-twitter"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                                class="fa fa-twitch"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                                class="fa fa-youtube"></i></a></th>
-                                    <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                                class="fab fa-discord"></i></a></th>
-                                </tr>
-                            </table> &copy;2020 Unitary Fund
-                        </footer>
-                    </div>
-                    <div class="col-1" id="menu-container">
-                        <table style="width:auto; margin-right:0px; margin-left: auto;">
-                            <tr>
-                                <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                            class="fa fa-twitter"></i></a></th>
-                                <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                            class="fa fa-twitch"></i></a></th>
-                                <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                            class="fa fa-youtube"></i></a></th>
-                                <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                            class="fab fa-discord"></i></a></th>
-                            </tr>
-                        </table>
-                        <p class="light" id="menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html" class="active">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                    <div id="mobile-menu-container">
-                        <p class="light" id="mobile-menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html" class="active">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                </div>
-            </section>
-        </main>
+              <footer class="footer leading-arrow light-arrow">
+                This website is hosted on
+                <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community
+                follows this
+                <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a
+                >. <br />
+                <br />
+                If you have suggestions for changes then please open up a pull request!
+                <br />
+                <br />
+                <table>
+                  <tr>
+                    <th style="text-align: right">
+                      <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"
+                        ><i class="fa fa-youtube"></i
+                      ></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                    </th>
+                  </tr>
+                </table>
+                &copy;2020 Unitary Fund
+              </footer>
+            </div>
+            <div class="col-1" id="menu-container">
+              <table style="width: auto; margin-right: 0px; margin-left: auto">
+                <tr>
+                  <th style="text-align: right">
+                    <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                  </th>
+                </tr>
+              </table>
+              <p class="light" id="menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html" class="active">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+            <div id="mobile-menu-container">
+              <p class="light" id="mobile-menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html" class="active">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
     <script>
-        var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
-        mobileMenuContainer = document.querySelector("#mobile-menu-container");
-        mobileMenuIcon.addEventListener("click", function() {
-            mobileMenuIcon.classList.toggle("is-active");
-            mobileMenuContainer.classList.toggle("active");
-        });
+      var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
+      mobileMenuContainer = document.querySelector("#mobile-menu-container")
+      mobileMenuIcon.addEventListener("click", function () {
+        mobileMenuIcon.classList.toggle("is-active")
+        mobileMenuContainer.classList.toggle("active")
+      })
     </script>
-</body>
-
+  </body>
 </html>

--- a/donate.html
+++ b/donate.html
@@ -53,7 +53,7 @@
                 <div class="container">
                     <div class="col-3">
                         <div class="hero">
-                            <a href="/"><img src="/logos/logov3.svg" alt="Unitary Fund" /></a>
+                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
                             <p class="tagline"><b>Because evolution is
                                     <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
                                         target="_blank">unitary</a></b>.</p>

--- a/donate.html
+++ b/donate.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 
 <html>
-<script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -32,6 +31,7 @@
         }
     </style>
 
+    <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>

--- a/donate.html
+++ b/donate.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/donate.html
+++ b/donate.html
@@ -74,7 +74,7 @@
                         <!-- INSERT PAYPAL HTML HERE -->
 
                         <div style="display: block; margin-left: auto; margin-right: auto; width: 50%;">
-                            <a href="https://www.paypal.com/donate/?cmd=_s-xclick&hosted_button_id=NYN7D2ADDYQ78&source=url"><img src="images/donate-button.png" alt="donate button" width="100%"></a>
+                            <a href="https://www.paypal.com/donate/?cmd=_s-xclick&hosted_button_id=NYN7D2ADDYQ78&source=url"><img src="images/donate-button.png" alt="donate button"></a>
                             <br> via PayPal
                         </div>
 

--- a/donate.html
+++ b/donate.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
-    <style type="text/css">
+    <style>
       #mc_embed_signup {
         background: #fff;
         clear: left;

--- a/faq.html
+++ b/faq.html
@@ -65,7 +65,7 @@
                   </span>
                 </button>
               </div>
-              <p class="subtitle leading-arrow"><a name="faq">F.A.Q.</a></p>
+              <p class="subtitle leading-arrow">F.A.Q.</p>
 
               <p>
                 <b>Q: Can anyone apply for a grant?</b> <br />

--- a/faq.html
+++ b/faq.html
@@ -1,246 +1,314 @@
 <!DOCTYPE html>
 
 <html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
 
     <title>Unitary Fund</title>
     <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="style.css">
-    <link rel="stylesheet" type="text/css" href="hamburgers.min.css">
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
-    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-        #mc_embed_signup {
-            background: #fff;
-            clear: left;
-            font: 14px "Lucida Console", Monaco, monospace;
-            width: 100%;
-        }
-        
-        #mce-EMAIL {
-            padding: 11px;
-            margin: 10px;
-        }
+      #mc_embed_signup {
+        background: #fff;
+        clear: left;
+        font: 14px "Lucida Console", Monaco, monospace;
+        width: 100%;
+      }
+
+      #mce-EMAIL {
+        padding: 11px;
+        margin: 10px;
+      }
     </style>
 
     <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
+      window.dataLayer = window.dataLayer || []
 
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-        gtag('config', 'UA-19932157-4');
+      gtag("config", "UA-19932157-4")
     </script>
-</head>
+  </head>
 
-<body>
+  <body>
     <div class="layout">
-        <main id="content" class="content">
-            <section class="heavy">
-                <div class="container">
-                    <div class="col-3">
-                        <div class="hero">
-                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
-                            <p class="tagline"><b>Because evolution is
-                                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
-                                        target="_blank">unitary</a></b>.</p>
-                            <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
-                                <span class="hamburger-box">
-                                    <span class="hamburger-inner"></span>
-                                </span>
-                            </button>
-                        </div>
-                        <p class="subtitle leading-arrow"><a name="faq">F.A.Q.</a></p>
+      <main id="content" class="content">
+        <section class="heavy">
+          <div class="container">
+            <div class="col-3">
+              <div class="hero">
+                <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
+                <p class="tagline">
+                  <b
+                    >Because evolution is
+                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b
+                  >.
+                </p>
+                <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
+                  <span class="hamburger-box">
+                    <span class="hamburger-inner"></span>
+                  </span>
+                </button>
+              </div>
+              <p class="subtitle leading-arrow"><a name="faq">F.A.Q.</a></p>
 
-                        <p>
-                            <b>Q: Can anyone apply for a grant?</b> <br> Yes - applicants can be any age and from any country. No credentials are required.<br><br>
+              <p>
+                <b>Q: Can anyone apply for a grant?</b> <br />
+                Yes - applicants can be any age and from any country. No credentials are required.<br /><br />
 
-                            <b>Q: What type of project qualifies for consideration?</b> <br> We are interested in projects that leverage and support quantum technology to benefit humanity. Projects are not strictly required to be open source or open publication
-                            - though we recommend it as a starting point. It is, however, important to provide a rationale in your application for any exceptions (for example, if you think it'd be best for the world to reserve the IP for a company).<br><br>
+                <b>Q: What type of project qualifies for consideration?</b>
+                <br />
+                We are interested in projects that leverage and support quantum technology to benefit humanity. Projects
+                are not strictly required to be open source or open publication - though we recommend it as a starting
+                point. It is, however, important to provide a rationale in your application for any exceptions (for
+                example, if you think it'd be best for the world to reserve the IP for a company).<br /><br />
 
-                            <b>Q: Is there a recommended duration for projects?</b> <br> We prefer projects that can be completed within 3-6 months. However, if there is a reason that your project should have a longer timeline, then include that in your
-                            application and we will consider it.
-                            <br><br>
+                <b>Q: Is there a recommended duration for projects?</b> <br />
+                We prefer projects that can be completed within 3-6 months. However, if there is a reason that your
+                project should have a longer timeline, then include that in your application and we will consider it.
+                <br /><br />
 
-                            <b>Q: What happens next if I win?</b> <br> We'll publish a list of all the winners on <a href="http://unitary.fund" target="_blank">unitary.fund</a> and you will receive 50% of your grant up front. Payment will come by Paypal
-                            or wire transfer. Additionally, you can opt in to receive expanded access to cloud-based quantum hardware from <a href="https://www.rigetti.com/" target="_blank">Rigetti QCS</a>, <a href="https://azure.microsoft.com/en-us/services/quantum/#overview"
-                                target="_blank">Azure Quantum</a> and <a href="https://www.ibm.com/quantum-computing/" target="_blank">IBM Quantum</a> (read our blog post about the IBM Quantum benefits <a href="posts/ibmq_access.html" target="_blank">here</a>).
-                            <br><br> Around the midpoint of your project, we'll check in with you for a progress update before sending the second half of your grant. Finally, we'll do a follow-up phone call or email upon the completion of your project
-                            to hear how it went, and we'll ask you to submit a short summary that can be posted online. <br><br>
+                <b>Q: What happens next if I win?</b> <br />
+                We'll publish a list of all the winners on
+                <a href="http://unitary.fund" target="_blank">unitary.fund</a>
+                and you will receive 50% of your grant up front. Payment will come by Paypal or wire transfer.
+                Additionally, you can opt in to receive expanded access to cloud-based quantum hardware from
+                <a href="https://www.rigetti.com/" target="_blank">Rigetti QCS</a>,
+                <a href="https://azure.microsoft.com/en-us/services/quantum/#overview" target="_blank">Azure Quantum</a>
+                and
+                <a href="https://www.ibm.com/quantum-computing/" target="_blank">IBM Quantum</a>
+                (read our blog post about the IBM Quantum benefits
+                <a href="posts/ibmq_access.html" target="_blank">here</a>). <br /><br />
+                Around the midpoint of your project, we'll check in with you for a progress update before sending the
+                second half of your grant. Finally, we'll do a follow-up phone call or email upon the completion of your
+                project to hear how it went, and we'll ask you to submit a short summary that can be posted online.
+                <br /><br />
 
+                <b>Q: What happens at the halfway check-in?</b> <br />
+                We'll have a call with you and our advisors where we want to know:
+              </p>
+              <ul>
+                <li>What have you built so far?</li>
+                <li>What are you building next?</li>
+                <li>What lessons have you learned so far?</li>
+                <li>How can we help with what is coming next?</li>
+              </ul>
+              <p>
+                This helps us evaluate if the project is on-track to merit the second half of grant funding.
+                <br /><br />
 
+                <b>Q: What happens if my project doesn't progress sufficiently in the first half?</b>
+                <br />
+                We expect this to happen sometimes because we fund risky, early stage projects. If all projects
+                succeeded, then we wouldn't be taking on sufficient risk. If this happens with your project, then the
+                second half won't be funded. Still, we'd encourage you to think about failure as a critical part of
+                learning and exploration. Furthermore, we'll be happy to look at future proposals from previous grantees
+                who didn't succeed in their first attempt. We know you'll have learned from the experience.
+                <br /><br />
 
+                <b>Q: What are the key dates for applying?</b> <br />
+                There are no key dates! Applications are rolling until all grant money has been allocated. <br /><br />
 
-                            <b>Q: What happens at the halfway check-in?</b> <br> We'll have a call with you and our advisors where we want to know:
-                        </p>
-                            <ul>
-                                <li>What have you built so far?</li>
-                                <li>What are you building next?</li>
-                                <li>What lessons have you learned so far?</li>
-                                <li>How can we help with what is coming next?</li>
-                            </ul>
-                        <p>
-                            This helps us evaluate if the project is on-track to merit the second half of grant funding.
-                            <br><br>
+                <b>Q: What kind of projects are you looking for?</b> <br />
+                Quantum technology is a nascent field, so we're open-minded. Your project can be:
+              </p>
+              <ul>
+                <li>contributing to an existing open source project</li>
+                <li>creating a new framework or tool</li>
+                <li>researching a new algorithm</li>
+                <li>building a quantum hardware prototype</li>
+                <li>running a new workshop or course</li>
+                <li>applying an existing algorithm to a new problem</li>
+                <li>creating or curating a free dataset that others can use</li>
+                <li>educating, explaining, or otherwise helping people learn new or existing techniques</li>
+              </ul>
 
-                            <b>Q: What happens if my project doesn't progress sufficiently in the first half?</b> <br> We expect this to happen sometimes because we fund risky, early stage projects. If all projects succeeded, then we wouldn't be taking
-                            on sufficient risk. If this happens with your project, then the second half won't be funded. Still, we'd encourage you to think about failure as a critical part of learning and exploration. Furthermore, we'll be happy to look
-                            at future proposals from previous grantees who didn't succeed in their first attempt. We know you'll have learned from the experience.
-                            <br><br>
+              <p>
+                …or anything else that you feel would accelerate the utility of quantum technology.<br /><br />
+                In some cases, particularly for projects involving hardware, we know that our grant likely won't be
+                enough for the whole project. We're happy for our grant to supplement existing work, though we would
+                like to see justification in your application for why the project could use our support.<br /><br />
 
-                            <b>Q: What are the key dates for applying?</b> <br> There are no key dates! Applications are rolling until all grant money has been allocated.
-                            <br><br>
+                <b
+                  >Q: Do you fund projects that are contributions to existing open source packages and not just stand
+                  alone projects?</b
+                >
+                <br />
+                Yes! In many cases, contributing to an existing project/package will help your work have a lot more
+                impact. We have often recommended this approach to applicants.<br /><br />
 
-                            <b>Q: What kind of projects are you looking for?</b> <br> Quantum technology is a nascent field, so we're open-minded. Your project can be:
-                        </p>
-                        <ul>
-                            <li>contributing to an existing open source project</li>
-                            <li>creating a new framework or tool</li>
-                            <li>researching a new algorithm</li>
-                            <li>building a quantum hardware prototype</li>
-                            <li>running a new workshop or course</li>
-                            <li>applying an existing algorithm to a new problem</li>
-                            <li>creating or curating a free dataset that others can use</li>
-                            <li>educating, explaining, or otherwise helping people learn new or existing techniques</li>
-                        </ul>
+                <b>Q: How will you select the winners?</b> <br />
+                We're looking for smart people with interesting ideas that could be useful to the world. We pay extra
+                attention to projects that seem like they won't get funded another way. <br /><br />
 
-                        <p>
-                            …or anything else that you feel would accelerate the utility of quantum technology.<br><br> In some cases, particularly for projects involving hardware, we know that our grant likely won't be enough for the whole project. We're
-                            happy for our grant to supplement existing work, though we would like to see justification in your application for why the project could use our support.<br><br>
+                <b>Q: What are project funds often used for?</b> <br />
+                In your application, we ask how you plan to use the funds. Each project is different and we encourage
+                creative suggestions for how to best make use of the grants. Previous successful grants have used funds
+                for:
+              </p>
+              <ul>
+                <li>developer or researcher time</li>
+                <li>hardware or software licenses</li>
+                <li>publication or distribution costs</li>
+                <li>hosting and computing resources</li>
+                <li>contributions to open source tools used by the project</li>
+                <li>travel expenses</li>
+              </ul>
 
-                            <b>Q: Do you fund projects that are contributions to existing open source packages and not
-                                just stand alone projects?</b> <br> Yes! In many cases, contributing to an existing project/package will help your work have a lot more impact. We have often recommended this approach to applicants.<br><br>
+              <p>
+                <b>Q: I have a job. Can I still apply?</b> <br />
+                Yes! Anyone can apply. You just need to make sure that you don't conflict with any IP contract you've
+                signed with your employer.
+                <br /><br />
 
-                            <b>Q: How will you select the winners?</b> <br> We're looking for smart people with interesting ideas that could be useful to the world. We pay extra attention to projects that seem like they won't get funded another way. <br><br>
+                <b>Q: Can teams apply?</b> <br />
+                Yes. Multiple people can apply together as a team. Please fill out a single application and provide
+                background information for each person on the team. You should designate a lead person to coordinate the
+                application, as well as to receive and distribute the money. <br /><br />
 
-                            <b>Q: What are project funds often used for?</b> <br> In your application, we ask how you plan to use the funds. Each project is different and we encourage creative suggestions for how to best make use of the grants. Previous
-                            successful grants have used funds for:
-                        </p>
-                        <ul>
-                            <li>developer or researcher time</li>
-                            <li>hardware or software licenses</li>
-                            <li>publication or distribution costs</li>
-                            <li>hosting and computing resources</li>
-                            <li>contributions to open source tools used by the project</li>
-                            <li>travel expenses</li>
-                        </ul>
+                <b>Q: Can I apply multiple times?</b> <br />
+                Yes, you can apply as often as you like. You can win multiple times, and we will consider repeat funding
+                to continue to grow a project to the next level.
+                <br /><br />
 
-                        <p>
-                        <b>Q: I have a job. Can I still apply?</b> <br> Yes! Anyone can apply. You just need to make sure that you don't conflict with any IP contract you've signed with your employer. <br><br>
+                <b
+                  >Q: I love this idea and I want to help! Can I provide additional funding, datasets, mentorship, or
+                  help reviewing applications?</b
+                >
+                <br />
+                Yes! Thank you for being awesome! If you want to contribute in any way, please email us at
+                <a href="mailto:contribute@unitary.fund">contribute@unitary.fund</a>.<br /><br />
 
-                        <b>Q: Can teams apply?</b> <br> Yes. Multiple people can apply together as a team. Please fill out a single application and provide background information for each person on the team. You should designate a lead person to coordinate
-                        the application, as well as to receive and distribute the money. <br><br>
+                <b>Q: Are there any strings attached?</b> <br />
+                The money is a gift. It's not an equity investment or loan, and we won't own any of your intellectual
+                property. Our only request is that you think about how to pay it forward to others.<br /><br />
 
-                        <b>Q: Can I apply multiple times?</b> <br> Yes, you can apply as often as you like. You can win multiple times, and we will consider repeat funding to continue to grow a project to the next level.
-                        <br><br>
+                <b>Q: How long after applying should I expect a reply?</b>
+                <br />
+                We aim to get back to applicants within a month.<br /><br />
 
-                        <b>Q: I love this idea and I want to help! Can I provide additional funding, datasets,
-                            mentorship, or help
-                            reviewing applications?</b> <br> Yes! Thank you for being awesome! If you want to contribute in any way, please email us at
-                        <a href="mailto:contribute@unitary.fund">contribute@unitary.fund</a>.<br><br>
+                <b>Q: Are applications private?</b> <br />
+                Yes. Applications are only reviewed by the Unitary Fund team and advisors. They are kept
+                confidential.<br /><br />
 
-                        <b>Q: Are there any strings attached?</b> <br> The money is a gift. It's not an equity investment or loan, and we won't own any of your intellectual property. Our only request is that you think about how to pay it forward to others.<br><br>
-
-                        <b>Q: How long after applying should I expect a reply?</b> <br> We aim to get back to applicants within a month.<br><br>
-
-                        <b>Q: Are applications private?</b> <br> Yes. Applications are only reviewed by the Unitary Fund team and advisors. They are kept confidential.<br><br>
-
-                        <b>Q: Where did you get the idea to do this?</b> <br> This program is inspired by, and directly borrows from
-                        <a href="https://twitter.com/natfriedman" target="_blank">Nat Friedman</a> and
-                        <a href="https://twitter.com/danielgross" target="_blank">Daniel Gross</a> and their
-                        <a href="https://aigrant.org/" target="_blank">AI Grant Program</a>. Thanks, Nat and Daniel!
-                        <br> <br> That program is inspired by, and directly borrows many elements from
-                        <a href="https://twitter.com/nayafia" target="_blank">Nadia Eghbal</a> and her
-                        <a href="https://medium.com/@nayafia/5-000-no-strings-attached-9e7b95d33e50" target="_blank">no-strings-attached
-                            grant program</a>. Thanks, Nadia!
-
-                        </p>
-                        <footer class="footer leading-arrow light-arrow">
-                            This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
-                                of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request!
-                            <br>
-                            <br>
-                            <table>
-                                <tr>
-                                    <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                                class="fa fa-twitter"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                                class="fa fa-twitch"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                                class="fa fa-youtube"></i></a></th>
-                                    <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                                class="fab fa-discord"></i></a></th>
-                                </tr>
-                            </table> &copy;2020 Unitary Fund
-                        </footer>
-                    </div>
-                    <div class="col-1" id="menu-container">
-                        <table style="width:auto; margin-right:0px; margin-left: auto;">
-                            <tr>
-                                <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                            class="fa fa-twitter"></i></a></th>
-                                <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                            class="fa fa-twitch"></i></a></th>
-                                <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                            class="fa fa-youtube"></i></a></th>
-                                <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                            class="fab fa-discord"></i></a></th>
-                            </tr>
-                        </table>
-                        <p class="light" id="menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html" class="active">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                    <div id="mobile-menu-container">
-                        <p class="light" id="mobile-menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html" class="active">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                </div>
-            </section>
-        </main>
+                <b>Q: Where did you get the idea to do this?</b> <br />
+                This program is inspired by, and directly borrows from
+                <a href="https://twitter.com/natfriedman" target="_blank">Nat Friedman</a>
+                and
+                <a href="https://twitter.com/danielgross" target="_blank">Daniel Gross</a>
+                and their
+                <a href="https://aigrant.org/" target="_blank">AI Grant Program</a>. Thanks, Nat and Daniel! <br />
+                <br />
+                That program is inspired by, and directly borrows many elements from
+                <a href="https://twitter.com/nayafia" target="_blank">Nadia Eghbal</a>
+                and her
+                <a href="https://medium.com/@nayafia/5-000-no-strings-attached-9e7b95d33e50" target="_blank"
+                  >no-strings-attached grant program</a
+                >. Thanks, Nadia!
+              </p>
+              <footer class="footer leading-arrow light-arrow">
+                This website is hosted on
+                <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community
+                follows this
+                <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a
+                >. <br />
+                <br />
+                If you have suggestions for changes then please open up a pull request!
+                <br />
+                <br />
+                <table>
+                  <tr>
+                    <th style="text-align: right">
+                      <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"
+                        ><i class="fa fa-youtube"></i
+                      ></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                    </th>
+                  </tr>
+                </table>
+                &copy;2020 Unitary Fund
+              </footer>
+            </div>
+            <div class="col-1" id="menu-container">
+              <table style="width: auto; margin-right: 0px; margin-left: auto">
+                <tr>
+                  <th style="text-align: right">
+                    <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                  </th>
+                </tr>
+              </table>
+              <p class="light" id="menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html" class="active">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+            <div id="mobile-menu-container">
+              <p class="light" id="mobile-menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html" class="active">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
     <script>
-        var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
-        mobileMenuContainer = document.querySelector("#mobile-menu-container");
-        mobileMenuIcon.addEventListener("click", function() {
-            mobileMenuIcon.classList.toggle("is-active");
-            mobileMenuContainer.classList.toggle("active");
-        });
+      var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
+      mobileMenuContainer = document.querySelector("#mobile-menu-container")
+      mobileMenuIcon.addEventListener("click", function () {
+        mobileMenuIcon.classList.toggle("is-active")
+        mobileMenuContainer.classList.toggle("active")
+      })
     </script>
-</body>
-
+  </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -53,7 +53,7 @@
                 <div class="container">
                     <div class="col-3">
                         <div class="hero">
-                            <a href="/"><img src="/logos/logov3.svg" alt="Unitary Fund" /></a>
+                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
                             <p class="tagline"><b>Because evolution is
                                     <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
                                         target="_blank">unitary</a></b>.</p>

--- a/faq.html
+++ b/faq.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 
 <html>
-<script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -32,6 +31,7 @@
         }
     </style>
 
+    <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>

--- a/faq.html
+++ b/faq.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/faq.html
+++ b/faq.html
@@ -85,12 +85,14 @@
 
 
                             <b>Q: What happens at the halfway check-in?</b> <br> We'll have a call with you and our advisors where we want to know:
+                        </p>
                             <ul>
                                 <li>What have you built so far?</li>
                                 <li>What are you building next?</li>
                                 <li>What lessons have you learned so far?</li>
                                 <li>How can we help with what is coming next?</li>
                             </ul>
+                        <p>
                             This helps us evaluate if the project is on-track to merit the second half of grant funding.
                             <br><br>
 
@@ -136,6 +138,7 @@
                             <li>travel expenses</li>
                         </ul>
 
+                        <p>
                         <b>Q: I have a job. Can I still apply?</b> <br> Yes! Anyone can apply. You just need to make sure that you don't conflict with any IP contract you've signed with your employer. <br><br>
 
                         <b>Q: Can teams apply?</b> <br> Yes. Multiple people can apply together as a team. Please fill out a single application and provide background information for each person on the team. You should designate a lead person to coordinate

--- a/faq.html
+++ b/faq.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
-    <style type="text/css">
+    <style>
       #mc_embed_signup {
         background: #fff;
         clear: left;

--- a/grants.html
+++ b/grants.html
@@ -73,70 +73,71 @@
 
                         <p class="subtitle leading-arrow">Grants Made</p>
 
-                        <ul id="grant-list">
-                        <h4>2022 Grants</h4> 
-                        <br>
+                        <h4 class="grant-year">2022 Grants</h4> 
+                        <ul class="grant-list">
                            <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" id="homl" />
                                 <p>
                                     To <a class="recipient-link" href="https://steventhomson.co.uk/">Steven Thomson</a>, to create <a href="https://www.insidequantum.org">Inside Quantum</a>, a new quantum technology themed podcast focusing on the people behind the research, aimed at showcasing a diverse range of voices in order to promote inclusivity and inspire the next generation of quantum technologists. </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" id="homl" />
                                 <p>
                                     To <a class="recipient-link" href="https://twitter.com/atamb_">Ayush Tambde</a>, to develop a Higher-Level Oracle Description Language (HOML), so that the compiler can interoperate with other frameworks/languages (OpenQASM, QIR). [<a href="https://arxiv.org/abs/2110.12487
 ">arXiv</a>]                               </p>
-                            </li><br>
-                            <h4>2021 Grants</h4>
-                        <br>
+                            </li>
+                        </ul>
+                        
+                        <h4 class="grant-year">2021 Grants</h4>
+                        <ul class="grant-list">
                            <li>
 
                                 <img class="grant-image" src="images/dummy.png" alt="grant" id="2qan" />
                                 <p>
                                     To <a class="recipient-link" href="https://twitter.com/719lingling">Lingling Lao</a>, to develop 2QAN, a compiler that optimizes quantum circuits for 2-local qubit Hamiltonian simulation problems. [<a href="https://arxiv.org/abs/2108.02099
 ">arXiv</a>]                               </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" id="qutip-vqa" />
                                 <p>
                                     To <a class="recipient-link" href="https://benbraham.com">Ben Braham</a>, to develop a framework to define and run variational quantum algorithms in QuTiP, leveraging quantum optimal control to parametrize control pulses.
                                </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" id="qudit-simulator" />
                                 <p>
                                     To <a class="recipient-link" href="https://twitter.com/rmjh94">Hoang Van Do</a>, <a class="recipient-link" href="http://www.normalesup.org/~gouzien/">Elie Gouzien</a>, and <a class="recipient-link" href="https://twitter.com/saesunkim">Saesun Kim</a> to develop a Heisenberg-picture simulator and universal gate set for high dimensional systems.
                                </p>
-                            </li><br>
+                            </li>
 
                            <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" id="qworld" />
                                 <p>
                                     To Abuzer Yakaryilmaz and the <a href="https://twitter.com/qworld19">QWorld</a> team to organize <a class="recipient-link" href="https://qworld.net/qcourse511-1/">QCourse511</a>, a graduate-level online course on quantum computing and programming.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" id="lattice-surgery" />
                                 <p>
                                     To <b>George Watkins</b>, <b>Alex Nguyen</b>, <b>Varun Seshadri</b>, and <b>Keelan Watkins</b> to further develop a <a class="recipient-link" href="https://github.com/latticesurgery-com/lattice-surgery-compiler">lattice-surgery-based</a> quantum error correction compiler. [Demo at <a href="https://latticesurgery.com/">latticesurgery.com</a>]
                                 </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" id="qdot" />
                                 <p>
                                     To <b>Brian Shi</b> to build <a href="https://github.com/brs96/Qdot">Qdot</a>, a Scala 3 library (QASM-transpiler) that allows Scala/Java developers write native quantum/hybrid programs.
                                 </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" id="oqupy" />
                                 <p>
                                     To <a class="recipient-link" href="https://twitter.com/fuxgerald">Gerald E. Fux</a> and Dominic Gribben and the <a class="recipient-link" href="https://github.com/tempoCollaboration/TimeEvolvingMPO">TEMPO collaboration</a> to develop an open source python package for simulating non-Markovian open quantum systems using tensor network techniques. In particular, the grant will enable adding two new features: studying the role of environment correlation functions through observables of the system and of multiple environments coupled to a single system.
                                 </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" id="qleet" />
@@ -144,34 +145,34 @@
                                     To <a class="recipient-link" href="https://obliviateandsurrender.github.io">Utkarsh Azad</a> and <a class="recipient-link" href="https://researchweb.iiit.ac.in/~animesh.sinha/home">Animesh Sinha</a> to build a visualization
                                     tool called <a class="recipient-link" href="https://github.com/QLemma/qLEET">qLEET</a> for exploring loss landscapes, expressibility, entangling capacity and trainability for noisy, parameterized quantum circuits.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://www.linkedin.com/in/danny-samuel-9a8a621ba/">Danny Samuel</a> to improve and extend the performance of variational quantum algorithms with error mitigation, benchmarking them
                                     with mirror circuits.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To Lorenzo Buffoni, to develop <a class="recipient-link" href="https://github.com/Buffoni/SQWalk">SQWalk</a>, A Stochastic Quantum Walk simulator based on QuTiP.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To Jonas Schwab and the ALF collaboration, to develop <a class="recipient-link" href="https://git.physik.uni-wuerzburg.de/ALF/pyALF">pyALF</a>, the Python interface of the ALF project, a powerful and flexible package
                                     for Quantum Monte Carlo simulations of fermion systems.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To the teams at Orange Quantum Systems and Qblox, to develop <a class="recipient-link" href="https://quantify-quantify-core.readthedocs-hosted.com/en/stable/">Quantify Core</a>, an open-source Python-based data acquisition
                                     and experiment control platform for quantum computing and solid-state physics experiments. It is built on <a href="https://qcodes.github.io/Qcodes/">QCoDeS</a> and is a spiritual successor of <a href="https://github.com/DiCarloLab-Delft/PycQED_py3">PycQED</a>.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -180,14 +181,14 @@
                                     It is hosted at <a href="https://github.com/emilianomfortes/krylovsolver">GitHub</a>,
                                     and explained on <a href="https://medium.com/@julian.ruffinelli/krylov-approximation-method-for-quantum-evolution-148b3f023ec4">Medium</a>.
                                 </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To Reem Larabi to add more visualization improvements to the %debug tool in Q# by expanding its current set of controls.
                                 </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
@@ -195,7 +196,7 @@
                                     To Alessandro Luongo and Armando Bellante to develop <a class="recipient-link" href="https://quantumalgorithms.org">Quantumalgorithms.org</a> an open-source web book collecting in an organized manner lectures notes
                                     around quantum algorithms for information processing, data analysis and machine learning.
                                 </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
@@ -206,7 +207,7 @@
                                         Quantum
                                         Safe</a> project.
                                 </p>
-                            </li><br>
+                            </li>
 
 
                             <li>
@@ -215,7 +216,7 @@
                                     To <a class="recipient-link" href="https://github.com/lockwo">Owen Lockwood</a> to develop a software package using classical deep reinforcement learning to improve quantum optimization, both for quantum simulations
                                     and hardware integration.
                                 </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
@@ -224,7 +225,7 @@
                                         França</a> to develop a software package that will help benchmark the limitations of noisy quantum devices for solving optimization problems. [<a href="https://arxiv.org/pdf/2009.05532.pdf">arXiv</a>] [<a href="https://www.youtube.com/watch?v=00ULKjGu1-A">QIP talk on the
                                         technique</a>].
                                 </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
@@ -233,16 +234,18 @@
                                         DiAdamo</a> to further develop <a class="recipient-link" href="https://github.com/Interlin-q/Interlin-q/">Interlin-q</a>, a distributed quantum-enabled simulator integrated with QuNetSim. [<a href="https://arxiv.org/abs/2106.06841">arXiv</a>]
                                     [<a href="https://medium.com/@stephen.diadamo/distributed-quantum-computing-1c5d38a34c50">blog post</a>]
                                 </p>
-                            </li><br>
-                        <h4>2020 Grants</h4>
-                        <br>
+                            </li>
+                        </ul>
+
+                        <h4 class="grant-year">2020 Grants</h4>
+                        <ul class="grant-list">
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://dlasecki.github.io/">Dariusz Lasecki</a> to build an open-source Python library that delivers easy-to-use high-quality pre-trained machine learning models to predict good QAOA
                                     starting parameters for selected classes of problems.
                                 </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
@@ -250,7 +253,7 @@
                                     To Oscar Higgott, to continue developing and maintaining <a class="recipient-link" href="https://github.com/oscarhiggott/PyMatching">PyMatching</a>, a Python package for decoding quantum error correcting codes with
                                     minimum-weight perfect matching (MWPM). [<a href="https://arxiv.org/abs/2105.13082">arXiv</a>]
                                 </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
@@ -258,7 +261,7 @@
                                     To Nicola Mosco, to develop <a class="recipient-link" href="https://gitlab.com/homodyne-ct/MartaCT.jl">Marta CT</a>, a software package in Julia for medical diagnostics that uses a quantum-tomography-inspired technique
                                     for state reconstruction in order to reduce the radiation dose patients receive. [<a href="https://arxiv.org/abs/2106.12353">arXiv</a>]
                                 </p>
-                            </li><br>
+                            </li>
 
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
@@ -267,47 +270,47 @@
                                     <a class="recipient-link" href="https://qworld.lu.lv/">QWorld</a>, team, a follow-up grant to be incorporated as a non-profit organization and step up their activities. [
                                     <a href="https://arxiv.org/abs/2010.13552">arXiv</a>]
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To the team at
                                     <a class="recipient-link" href="https://www.qubitbyqubit.org/">Qubit By Qubit</a>, to develop courses and materials to educate a diverse ecosystem of open source quantum contributors.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To Pedro Rivero Ramírez for
                                     <a class="recipient-link" href="https://github.com/pedrorrivero/qrand/">QRand</a>, a multi-platform quantum random number generator library integrated with numpy.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="http://jemisjoky.com/">Jacob Miller</a> for a PyTorch toolbox for matrix product state models.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://rochisha0.github.io/">Rochisha
                                         Agarwal</a> and <a class="recipient-link" href="https://www.linkedin.com/in/natanshmathur/">Natansh Mathur</a> to create a <a href="https://github.com/Quantum-Machine-Learning-Textbook/Book">Machine Learning Textbook</a>                                    with integrated code and visualization.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://markcunningham.tech/">Mark Cunningham</a> to explore applications of quantum computing to medical imaging.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://github.com/splch">Spencer Churchill</a> to write
                                     <a href="https://quantumtales.org">Quantum Tales</a>, a series of fairy tales where quantum algorithms are applied to resolve their conflicts.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -316,7 +319,7 @@
                                     <a href="https://arxiv.org/abs/2007.15671">arXiv</a>] [
                                     <a href="https://arxiv.org/abs/2002.09783">arXiv</a>]
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -325,7 +328,7 @@
                                     <a href="https://fullstackquantumcomputation.tech/">site</a>] [
                                     <a href="https://discord.com/invite/NDm9e9W">discord</a>]
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -334,7 +337,7 @@
                                     <a class="recipient-link" href="https://www.sckaiser.com/">Sarah Kaiser</a> to build and optimize an open source Q# library for quantum RAM. [
                                     <a href="https://github.com/qsharp-community/qram">github</a>]
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -343,7 +346,7 @@
                                         development</a>, which includes an extensible DSL infrastructure, Julia-based frontend, Julia AST and QASM code generator, and a quantum circuit simplification infrastructure based on pattern matching. [
                                     <a href="https://github.com/QuantumBFS/YaoLang.jl">github</a>]
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -353,7 +356,7 @@
                                     <a href="https://github.com/watermarkhu/qsurface">github</a>] [
                                     <a href="https://qsurface.readthedocs.io/en/latest/index.html">Docs</a>]
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -361,13 +364,13 @@
                                         Farooq</a> for a research internship in the
                                     <a href="http://penghuiyao.info/">Yao group</a> that lost funding due to the COVID crisis. They aim to construct a quantum channel with a Classical input Reverse Information Cost of zero.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://dlasecki.github.io/">Dariusz Lasecki</a> to build an open source QAOA library and examples using Q#.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -377,7 +380,7 @@
                                     <a href="https://arxiv.org/abs/2003.06397">arXiv</a>] [
                                     <a href="https://www.youtube.com/watch?v=HE6jWjW1WT8">video</a>]
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -387,9 +390,11 @@
                                     [<a href="https://joss.theoj.org/papers/10.21105/joss.03082">paper</a>]
                                     [<a href="https://www.youtube.com/watch?v=6R7qSszJwBI">video</a>]
                                 </p>
-                            </li><br>
-                            <h4>2019 Grants</h4>
-                        <br>
+                            </li>
+                        </ul>
+
+                        <h4 class="grant-year">2019 Grants</h4>
+                        <ul class="grant-list">
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -402,7 +407,7 @@
                                     <a href="https://github.com/stared/quantum-game-2">QuantumGame - Github</a>] [
                                     <a href="https://github.com/Quantum-Game/bra-ket-vue">Bra-Ket-Vue - Github</a>]
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -410,7 +415,7 @@
                                         Obeid</a> and the <a class="recipient-link" href="https://qhyp.info/">QHyp</a> project, developing research and software at the intersection of quantum contextuality and probabilistic programming. [
                                     <a href="https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0208555">Publication</a>]
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -418,7 +423,7 @@
                                     <a href="https://qrack.readthedocs.io/en/latest/index.html">Docs</a>] [
                                     <a href="https://qrack.readthedocs.io/en/latest/performance.html">Benchmarks</a>]
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -428,7 +433,7 @@
                                         Herr</a> to develop zxQentiana an open source, resource estimator for time and space tradeoffs for the surface code that uses pyZX compilation. [
                                     <a href="https://github.com/quantumresource/zxQentiana">github</a>]
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -436,7 +441,7 @@
                                     of their quantum programming <a href="http://qworld.lu.lv/index.php/workshop-bronze/">workshops</a> and <a href="http://qworld.lu.lv/index.php/qkitchen/">educational materials</a>. [
                                     <a href="http://qworld.lu.lv/index.php/unitary-fund/">Workshops we funded</a>]
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -444,16 +449,18 @@
                                     <a href="https://www.scigym.net/env/gym-surfacecode">training a surface code
                                         decoder.</a>
                                 </p>
-                            </li><br>
-                        <h4>2018 Grants</h4>
-                        <br>
+                            </li>
+                        </ul>
+
+                        <h4 class="grant-year">2018 Grants</h4>
+                        <ul class="grant-list">
                         <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="http://www.gate42.org/">Gate42</a> to build an open source library for quantum error mitigation and dynamical decoupling: both techniques for compiling programs to reduce the effect
                                     of noise in quantum processors.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -463,7 +470,7 @@
                                     <a href="https://scirate.com/arxiv/2003.01695">[arXiv]</a>
                                     <a href="https://link.aps.org/doi/10.1103/PhysRevA.102.032420">[publ.]</a>
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -473,7 +480,7 @@
                                     <a href="https://twitter.com/quantcirc">[Twitter]</a>
                                     <a href="https://quantum-circuit.com/">[Website]</a>
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -482,7 +489,7 @@
                                         probabilistic programming language for quantum computing</a>. This library is called
                                     <a href="https://github.com/LSaldyt/qurry">Qurry</a>.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -496,7 +503,7 @@
                                     <a href="https://www.youtube.com/watch?v=iC-KVdB8pf0">[Video]</a>
                                     <a href="http://zxcalculus.com/">[Website]</a>
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -506,14 +513,14 @@
                                     <a href="https://github.com/libtangle">libraries</a>] [
                                     <a href="https://libtangle.com/">website</a>].
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://github.com/ntwalibas" target="_blank">Ntwali Bashige</a> to develop the
                                     <a href="https://github.com/ntwalibas/unitary-proposal" target="_blank">Avalon</a> quantum programming language and quantum programming communities in India and D. R. Congo.
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -524,7 +531,7 @@
                                         code (it's not live anymore)]</a>
 
                                 </p>
-                            </li><br>
+                            </li>
                             <li>
                                 <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
@@ -535,8 +542,9 @@
                                     <a href="https://arxiv.org/abs/2002.06210" target="_blank">[arXiv]</a>
                                     <a href="https://quantum-journal.org/papers/q-2020-05-28-272/" target="_blank">[publication]</a>
                                 </p>
-                            </li><br>
+                            </li>
                         </ul>
+
                         <footer class="footer leading-arrow light-arrow">
                             This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
                                 of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request!

--- a/grants.html
+++ b/grants.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 
 <html>
-<script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -32,6 +31,7 @@
         }
     </style>
 
+    <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>

--- a/grants.html
+++ b/grants.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/grants.html
+++ b/grants.html
@@ -510,14 +510,14 @@
                             <li>
                                 <img class="grant-image" src="/images/dummy.png" alt="grant" />
                                 <p>
-                                    To <a class="recipient-link" href="https://github.com/ntwalibas" , target="_blank">Ntwali Bashige</a> to develop the
-                                    <a href="https://github.com/ntwalibas/unitary-proposal" , target="_blank">Avalon</a> quantum programming language and quantum programming communities in India and D. R. Congo.
+                                    To <a class="recipient-link" href="https://github.com/ntwalibas" target="_blank">Ntwali Bashige</a> to develop the
+                                    <a href="https://github.com/ntwalibas/unitary-proposal" target="_blank">Avalon</a> quantum programming language and quantum programming communities in India and D. R. Congo.
                                 </p>
                             </li><br>
                             <li>
                                 <img class="grant-image" src="/images/dummy.png" alt="grant" />
                                 <p>
-                                    To <a class="recipient-link" href="http://www.mustythoughts.com/about/" , target="_blank">Michał Stęchły</a> to build a traveling salesman solver web application and <a class="recipient-link" href="https://github.com/mstechly/quantum_tsp_tutorials">tutorials</a>                                    for Forest based on the quantum approximate optimization algorithm.
+                                    To <a class="recipient-link" href="http://www.mustythoughts.com/about/" target="_blank">Michał Stęchły</a> to build a traveling salesman solver web application and <a class="recipient-link" href="https://github.com/mstechly/quantum_tsp_tutorials">tutorials</a>                                    for Forest based on the quantum approximate optimization algorithm.
                                     <a href="https://github.com/mstechly/quantum_tsp_tutorials">[github tutorials]</a>
                                     <a href="https://www.mustythoughts.com/post/solving-the-traveling-salesman-problem-using-quantum-computer">[blogpost]</a>
                                     <a href="https://github.com/BOHRTECHNOLOGY/tsp-demo-unitary-fund">[web app source
@@ -528,7 +528,7 @@
                             <li>
                                 <img class="grant-image" src="/images/dummy.png" alt="grant" />
                                 <p>
-                                    To <a class="recipient-link" href="https://twitter.com/charl_bp" , target="_blank">
+                                    To <a class="recipient-link" href="https://twitter.com/charl_bp" target="_blank">
                                         Carlos Bravo Prieto </a> to implement the Adiabatically Assisted Variational Quantum Eigensolvers in Forest, a hybrid classical-quantum algorithm for solving optimization problems.
                                     <a href="https://github.com/bpcarlos/AAVQE-Tutorial" target="_blank">[github
                                         tutorial]</a>

--- a/grants.html
+++ b/grants.html
@@ -1,623 +1,851 @@
 <!DOCTYPE html>
 
 <html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
 
     <title>Unitary Fund</title>
     <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="style.css">
-    <link rel="stylesheet" type="text/css" href="hamburgers.min.css">
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
-    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-        #mc_embed_signup {
-            background: #fff;
-            clear: left;
-            font: 14px "Lucida Console", Monaco, monospace;
-            width: 100%;
-        }
+      #mc_embed_signup {
+        background: #fff;
+        clear: left;
+        font: 14px "Lucida Console", Monaco, monospace;
+        width: 100%;
+      }
 
-        #mce-EMAIL {
-            padding: 11px;
-            margin: 10px;
-        }
+      #mce-EMAIL {
+        padding: 11px;
+        margin: 10px;
+      }
     </style>
 
     <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
+      window.dataLayer = window.dataLayer || []
 
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-        gtag('config', 'UA-19932157-4');
+      gtag("config", "UA-19932157-4")
     </script>
-</head>
+  </head>
 
-<body>
+  <body>
     <div class="layout">
-        <main id="content" class="content">
-            <section class="heavy">
-                <div class="container">
-                    <div class="col-3">
-                        <div class="hero">
-                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
-                            <p class="tagline"><b>Because evolution is
-                                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
-                                        target="_blank">unitary</a></b>.</p>
-                            <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
-                                <span class="hamburger-box">
-                                    <span class="hamburger-inner"></span>
-                                </span>
-                            </button>
-                        </div>
+      <main id="content" class="content">
+        <section class="heavy">
+          <div class="container">
+            <div class="col-3">
+              <div class="hero">
+                <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
+                <p class="tagline">
+                  <b
+                    >Because evolution is
+                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b
+                  >.
+                </p>
+                <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
+                  <span class="hamburger-box">
+                    <span class="hamburger-inner"></span>
+                  </span>
+                </button>
+              </div>
 
-                        <p>We’ve awarded microgrants to over 50 teams across 21 countries, resulting in 10+ completed or planned publications, welcoming 12 people into the field, and helping to form 2 new startups and 1 new non-profit.
-                        </p>
+              <p>
+                We’ve awarded microgrants to over 50 teams across 21 countries, resulting in 10+ completed or planned
+                publications, welcoming 12 people into the field, and helping to form 2 new startups and 1 new
+                non-profit.
+              </p>
 
-                        <p>Could you be next?
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" style="background-color:var(--color-yellow);">Apply here</a>.
-                        </p>
+              <p>
+                Could you be next?
+                <a
+                  href="https://unitaryfund.typeform.com/to/j0kAOd"
+                  target="_blank"
+                  style="background-color: var(--color-yellow)"
+                  >Apply here</a
+                >.
+              </p>
 
-                        <p class="subtitle leading-arrow">Grants Made</p>
+              <p class="subtitle leading-arrow">Grants Made</p>
 
-                        <h4 class="grant-year">2022 Grants</h4> 
-                        <ul class="grant-list">
-                           <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" id="inside-quantum" />
-                                <p>
-                                    To <a class="recipient-link" href="https://steventhomson.co.uk/">Steven Thomson</a>, to create <a href="https://www.insidequantum.org">Inside Quantum</a>, a new quantum technology themed podcast focusing on the people behind the research, aimed at showcasing a diverse range of voices in order to promote inclusivity and inspire the next generation of quantum technologists. </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" id="homl" />
-                                <p>
-                                    To <a class="recipient-link" href="https://twitter.com/atamb_">Ayush Tambde</a>, to develop a Higher-Level Oracle Description Language (HOML), so that the compiler can interoperate with other frameworks/languages (OpenQASM, QIR). [<a href="https://arxiv.org/abs/2110.12487
-">arXiv</a>]                               </p>
-                            </li>
-                        </ul>
-                        
-                        <h4 class="grant-year">2021 Grants</h4>
-                        <ul class="grant-list">
-                           <li>
+              <h4 class="grant-year">2022 Grants</h4>
+              <ul class="grant-list">
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="inside-quantum" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://steventhomson.co.uk/">Steven Thomson</a>, to create
+                    <a href="https://www.insidequantum.org">Inside Quantum</a>, a new quantum technology themed podcast
+                    focusing on the people behind the research, aimed at showcasing a diverse range of voices in order
+                    to promote inclusivity and inspire the next generation of quantum technologists.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="homl" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://twitter.com/atamb_">Ayush Tambde</a>, to develop a
+                    Higher-Level Oracle Description Language (HOML), so that the compiler can interoperate with other
+                    frameworks/languages (OpenQASM, QIR). [<a
+                      href="https://arxiv.org/abs/2110.12487
+"
+                      >arXiv</a
+                    >]
+                  </p>
+                </li>
+              </ul>
 
-                                <img class="grant-image" src="images/dummy.png" alt="grant" id="2qan" />
-                                <p>
-                                    To <a class="recipient-link" href="https://twitter.com/719lingling">Lingling Lao</a>, to develop 2QAN, a compiler that optimizes quantum circuits for 2-local qubit Hamiltonian simulation problems. [<a href="https://arxiv.org/abs/2108.02099
-">arXiv</a>]                               </p>
-                            </li>
+              <h4 class="grant-year">2021 Grants</h4>
+              <ul class="grant-list">
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="2qan" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://twitter.com/719lingling">Lingling Lao</a>, to develop 2QAN,
+                    a compiler that optimizes quantum circuits for 2-local qubit Hamiltonian simulation problems. [<a
+                      href="https://arxiv.org/abs/2108.02099
+"
+                      >arXiv</a
+                    >]
+                  </p>
+                </li>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" id="qutip-vqa" />
-                                <p>
-                                    To <a class="recipient-link" href="https://benbraham.com">Ben Braham</a>, to develop a framework to define and run variational quantum algorithms in QuTiP, leveraging quantum optimal control to parametrize control pulses.
-                               </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="qutip-vqa" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://benbraham.com">Ben Braham</a>, to develop a framework to
+                    define and run variational quantum algorithms in QuTiP, leveraging quantum optimal control to
+                    parametrize control pulses.
+                  </p>
+                </li>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" id="qudit-simulator" />
-                                <p>
-                                    To <a class="recipient-link" href="https://twitter.com/rmjh94">Hoang Van Do</a>, <a class="recipient-link" href="http://www.normalesup.org/~gouzien/">Elie Gouzien</a>, and <a class="recipient-link" href="https://twitter.com/saesunkim">Saesun Kim</a> to develop a Heisenberg-picture simulator and universal gate set for high dimensional systems.
-                               </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="qudit-simulator" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://twitter.com/rmjh94">Hoang Van Do</a>,
+                    <a class="recipient-link" href="http://www.normalesup.org/~gouzien/">Elie Gouzien</a>, and
+                    <a class="recipient-link" href="https://twitter.com/saesunkim">Saesun Kim</a>
+                    to develop a Heisenberg-picture simulator and universal gate set for high dimensional systems.
+                  </p>
+                </li>
 
-                           <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" id="qworld" />
-                                <p>
-                                    To Abuzer Yakaryilmaz and the <a href="https://twitter.com/qworld19">QWorld</a> team to organize <a class="recipient-link" href="https://qworld.net/qcourse511-1/">QCourse511</a>, a graduate-level online course on quantum computing and programming.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" id="lattice-surgery" />
-                                <p>
-                                    To <b>George Watkins</b>, <b>Alex Nguyen</b>, <b>Varun Seshadri</b>, and <b>Keelan Watkins</b> to further develop a <a class="recipient-link" href="https://github.com/latticesurgery-com/lattice-surgery-compiler">lattice-surgery-based</a> quantum error correction compiler. [Demo at <a href="https://latticesurgery.com/">latticesurgery.com</a>]
-                                </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="qworld" />
+                  <p>
+                    To Abuzer Yakaryilmaz and the
+                    <a href="https://twitter.com/qworld19">QWorld</a> team to organize
+                    <a class="recipient-link" href="https://qworld.net/qcourse511-1/">QCourse511</a>, a graduate-level
+                    online course on quantum computing and programming.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="lattice-surgery" />
+                  <p>
+                    To <b>George Watkins</b>, <b>Alex Nguyen</b>, <b>Varun Seshadri</b>, and <b>Keelan Watkins</b> to
+                    further develop a
+                    <a class="recipient-link" href="https://github.com/latticesurgery-com/lattice-surgery-compiler"
+                      >lattice-surgery-based</a
+                    >
+                    quantum error correction compiler. [Demo at
+                    <a href="https://latticesurgery.com/">latticesurgery.com</a>]
+                  </p>
+                </li>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" id="qdot" />
-                                <p>
-                                    To <b>Brian Shi</b> to build <a href="https://github.com/brs96/Qdot">Qdot</a>, a Scala 3 library (QASM-transpiler) that allows Scala/Java developers write native quantum/hybrid programs.
-                                </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="qdot" />
+                  <p>
+                    To <b>Brian Shi</b> to build <a href="https://github.com/brs96/Qdot">Qdot</a>, a Scala 3 library
+                    (QASM-transpiler) that allows Scala/Java developers write native quantum/hybrid programs.
+                  </p>
+                </li>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" id="oqupy" />
-                                <p>
-                                    To <a class="recipient-link" href="https://twitter.com/fuxgerald">Gerald E. Fux</a> and Dominic Gribben and the <a class="recipient-link" href="https://github.com/tempoCollaboration/TimeEvolvingMPO">TEMPO collaboration</a> to develop an open source python package for simulating non-Markovian open quantum systems using tensor network techniques. In particular, the grant will enable adding two new features: studying the role of environment correlation functions through observables of the system and of multiple environments coupled to a single system.
-                                </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="oqupy" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://twitter.com/fuxgerald">Gerald E. Fux</a>
+                    and Dominic Gribben and the
+                    <a class="recipient-link" href="https://github.com/tempoCollaboration/TimeEvolvingMPO"
+                      >TEMPO collaboration</a
+                    >
+                    to develop an open source python package for simulating non-Markovian open quantum systems using
+                    tensor network techniques. In particular, the grant will enable adding two new features: studying
+                    the role of environment correlation functions through observables of the system and of multiple
+                    environments coupled to a single system.
+                  </p>
+                </li>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" id="qleet" />
-                                <p>
-                                    To <a class="recipient-link" href="https://obliviateandsurrender.github.io">Utkarsh Azad</a> and <a class="recipient-link" href="https://researchweb.iiit.ac.in/~animesh.sinha/home">Animesh Sinha</a> to build a visualization
-                                    tool called <a class="recipient-link" href="https://github.com/QLemma/qLEET">qLEET</a> for exploring loss landscapes, expressibility, entangling capacity and trainability for noisy, parameterized quantum circuits.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://www.linkedin.com/in/danny-samuel-9a8a621ba/">Danny Samuel</a> to improve and extend the performance of variational quantum algorithms with error mitigation, benchmarking them
-                                    with mirror circuits.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To Lorenzo Buffoni, to develop <a class="recipient-link" href="https://github.com/Buffoni/SQWalk">SQWalk</a>, A Stochastic Quantum Walk simulator based on QuTiP.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To Jonas Schwab and the ALF collaboration, to develop <a class="recipient-link" href="https://git.physik.uni-wuerzburg.de/ALF/pyALF">pyALF</a>, the Python interface of the ALF project, a powerful and flexible package
-                                    for Quantum Monte Carlo simulations of fermion systems.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To the teams at Orange Quantum Systems and Qblox, to develop <a class="recipient-link" href="https://quantify-quantify-core.readthedocs-hosted.com/en/stable/">Quantify Core</a>, an open-source Python-based data acquisition
-                                    and experiment control platform for quantum computing and solid-state physics experiments. It is built on <a href="https://qcodes.github.io/Qcodes/">QCoDeS</a> and is a spiritual successor of <a href="https://github.com/DiCarloLab-Delft/PycQED_py3">PycQED</a>.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To Diego Ariel Wisniacki, Martin Larocca, Emiliano Manuel Fortes, Julian Matias Ruffinelli to develop Krylov evolution algorithms integrated with QuTiP.
-                                    [<a href="https://arxiv.org/abs/2010.03598">K-GRAPE</a>, <a href="https://arxiv.org/abs/2107.09805">Krylov-Loschmidt</a>].
-                                    It is hosted at <a href="https://github.com/emilianomfortes/krylovsolver">GitHub</a>,
-                                    and explained on <a href="https://medium.com/@julian.ruffinelli/krylov-approximation-method-for-quantum-evolution-148b3f023ec4">Medium</a>.
-                                </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="qleet" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://obliviateandsurrender.github.io">Utkarsh Azad</a>
+                    and
+                    <a class="recipient-link" href="https://researchweb.iiit.ac.in/~animesh.sinha/home"
+                      >Animesh Sinha</a
+                    >
+                    to build a visualization tool called
+                    <a class="recipient-link" href="https://github.com/QLemma/qLEET">qLEET</a>
+                    for exploring loss landscapes, expressibility, entangling capacity and trainability for noisy,
+                    parameterized quantum circuits.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://www.linkedin.com/in/danny-samuel-9a8a621ba/"
+                      >Danny Samuel</a
+                    >
+                    to improve and extend the performance of variational quantum algorithms with error mitigation,
+                    benchmarking them with mirror circuits.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To Lorenzo Buffoni, to develop
+                    <a class="recipient-link" href="https://github.com/Buffoni/SQWalk">SQWalk</a>, A Stochastic Quantum
+                    Walk simulator based on QuTiP.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To Jonas Schwab and the ALF collaboration, to develop
+                    <a class="recipient-link" href="https://git.physik.uni-wuerzburg.de/ALF/pyALF">pyALF</a>, the Python
+                    interface of the ALF project, a powerful and flexible package for Quantum Monte Carlo simulations of
+                    fermion systems.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To the teams at Orange Quantum Systems and Qblox, to develop
+                    <a class="recipient-link" href="https://quantify-quantify-core.readthedocs-hosted.com/en/stable/"
+                      >Quantify Core</a
+                    >, an open-source Python-based data acquisition and experiment control platform for quantum
+                    computing and solid-state physics experiments. It is built on
+                    <a href="https://qcodes.github.io/Qcodes/">QCoDeS</a> and is a spiritual successor of
+                    <a href="https://github.com/DiCarloLab-Delft/PycQED_py3">PycQED</a>.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To Diego Ariel Wisniacki, Martin Larocca, Emiliano Manuel Fortes, Julian Matias Ruffinelli to
+                    develop Krylov evolution algorithms integrated with QuTiP. [<a
+                      href="https://arxiv.org/abs/2010.03598"
+                      >K-GRAPE</a
+                    >, <a href="https://arxiv.org/abs/2107.09805">Krylov-Loschmidt</a>]. It is hosted at
+                    <a href="https://github.com/emilianomfortes/krylovsolver">GitHub</a>, and explained on
+                    <a
+                      href="https://medium.com/@julian.ruffinelli/krylov-approximation-method-for-quantum-evolution-148b3f023ec4"
+                      >Medium</a
+                    >.
+                  </p>
+                </li>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To Reem Larabi to add more visualization improvements to the %debug tool in Q# by expanding its current set of controls.
-                                </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To Reem Larabi to add more visualization improvements to the %debug tool in Q# by expanding its
+                    current set of controls.
+                  </p>
+                </li>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To Alessandro Luongo and Armando Bellante to develop <a class="recipient-link" href="https://quantumalgorithms.org">Quantumalgorithms.org</a> an open-source web book collecting in an organized manner lectures notes
-                                    around quantum algorithms for information processing, data analysis and machine learning.
-                                </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To Alessandro Luongo and Armando Bellante to develop
+                    <a class="recipient-link" href="https://quantumalgorithms.org">Quantumalgorithms.org</a>
+                    an open-source web book collecting in an organized manner lectures notes around quantum algorithms
+                    for information processing, data analysis and machine learning.
+                  </p>
+                </li>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://github.com/xvzcf">Goutam Tamvada</a> and
-                                    <a class="recipient-link" href="https://www.douglas.stebila.ca/">Douglas Stebila</a> to develop VeriFrodo, an open-source package implementing a lattice-based quantum-resistant cryptographic algorithms in Jasmin within
-                                    the <a class="recipient-link" href="https://github.com/open-quantum-safe">Open
-                                        Quantum
-                                        Safe</a> project.
-                                </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://github.com/xvzcf">Goutam Tamvada</a>
+                    and
+                    <a class="recipient-link" href="https://www.douglas.stebila.ca/">Douglas Stebila</a>
+                    to develop VeriFrodo, an open-source package implementing a lattice-based quantum-resistant
+                    cryptographic algorithms in Jasmin within the
+                    <a class="recipient-link" href="https://github.com/open-quantum-safe">Open Quantum Safe</a>
+                    project.
+                  </p>
+                </li>
 
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://github.com/lockwo">Owen Lockwood</a>
+                    to develop a software package using classical deep reinforcement learning to improve quantum
+                    optimization, both for quantum simulations and hardware integration.
+                  </p>
+                </li>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://github.com/lockwo">Owen Lockwood</a> to develop a software package using classical deep reinforcement learning to improve quantum optimization, both for quantum simulations
-                                    and hardware integration.
-                                </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://twitter.com/dsfranca">Daniel Stilck França</a>
+                    to develop a software package that will help benchmark the limitations of noisy quantum devices for
+                    solving optimization problems. [<a href="https://arxiv.org/pdf/2009.05532.pdf">arXiv</a>] [<a
+                      href="https://www.youtube.com/watch?v=00ULKjGu1-A"
+                      >QIP talk on the technique</a
+                    >].
+                  </p>
+                </li>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://twitter.com/dsfranca">Daniel Stilck
-                                        França</a> to develop a software package that will help benchmark the limitations of noisy quantum devices for solving optimization problems. [<a href="https://arxiv.org/pdf/2009.05532.pdf">arXiv</a>] [<a href="https://www.youtube.com/watch?v=00ULKjGu1-A">QIP talk on the
-                                        technique</a>].
-                                </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://twitter.com/RheaParekh1">Rhea Parekh</a>
+                    and
+                    <a class="recipient-link" href="https://scholar.google.ca/citations?user=k9O1vSwAAAAJ&hl=en"
+                      >Stephen DiAdamo</a
+                    >
+                    to further develop
+                    <a class="recipient-link" href="https://github.com/Interlin-q/Interlin-q/">Interlin-q</a>, a
+                    distributed quantum-enabled simulator integrated with QuNetSim. [<a
+                      href="https://arxiv.org/abs/2106.06841"
+                      >arXiv</a
+                    >] [<a href="https://medium.com/@stephen.diadamo/distributed-quantum-computing-1c5d38a34c50"
+                      >blog post</a
+                    >]
+                  </p>
+                </li>
+              </ul>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://twitter.com/RheaParekh1">Rhea Parekh</a> and <a class="recipient-link" href="https://scholar.google.ca/citations?user=k9O1vSwAAAAJ&hl=en">Stephen
-                                        DiAdamo</a> to further develop <a class="recipient-link" href="https://github.com/Interlin-q/Interlin-q/">Interlin-q</a>, a distributed quantum-enabled simulator integrated with QuNetSim. [<a href="https://arxiv.org/abs/2106.06841">arXiv</a>]
-                                    [<a href="https://medium.com/@stephen.diadamo/distributed-quantum-computing-1c5d38a34c50">blog post</a>]
-                                </p>
-                            </li>
-                        </ul>
+              <h4 class="grant-year">2020 Grants</h4>
+              <ul class="grant-list">
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://dlasecki.github.io/">Dariusz Lasecki</a>
+                    to build an open-source Python library that delivers easy-to-use high-quality pre-trained machine
+                    learning models to predict good QAOA starting parameters for selected classes of problems.
+                  </p>
+                </li>
 
-                        <h4 class="grant-year">2020 Grants</h4>
-                        <ul class="grant-list">
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://dlasecki.github.io/">Dariusz Lasecki</a> to build an open-source Python library that delivers easy-to-use high-quality pre-trained machine learning models to predict good QAOA
-                                    starting parameters for selected classes of problems.
-                                </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To Oscar Higgott, to continue developing and maintaining
+                    <a class="recipient-link" href="https://github.com/oscarhiggott/PyMatching">PyMatching</a>, a Python
+                    package for decoding quantum error correcting codes with minimum-weight perfect matching (MWPM). [<a
+                      href="https://arxiv.org/abs/2105.13082"
+                      >arXiv</a
+                    >]
+                  </p>
+                </li>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To Oscar Higgott, to continue developing and maintaining <a class="recipient-link" href="https://github.com/oscarhiggott/PyMatching">PyMatching</a>, a Python package for decoding quantum error correcting codes with
-                                    minimum-weight perfect matching (MWPM). [<a href="https://arxiv.org/abs/2105.13082">arXiv</a>]
-                                </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To Nicola Mosco, to develop
+                    <a class="recipient-link" href="https://gitlab.com/homodyne-ct/MartaCT.jl">Marta CT</a>, a software
+                    package in Julia for medical diagnostics that uses a quantum-tomography-inspired technique for state
+                    reconstruction in order to reduce the radiation dose patients receive. [<a
+                      href="https://arxiv.org/abs/2106.12353"
+                      >arXiv</a
+                    >]
+                  </p>
+                </li>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To Nicola Mosco, to develop <a class="recipient-link" href="https://gitlab.com/homodyne-ct/MartaCT.jl">Marta CT</a>, a software package in Julia for medical diagnostics that uses a quantum-tomography-inspired technique
-                                    for state reconstruction in order to reduce the radiation dose patients receive. [<a href="https://arxiv.org/abs/2106.12353">arXiv</a>]
-                                </p>
-                            </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To the
+                    <a class="recipient-link" href="https://qworld.lu.lv/">QWorld</a>, team, a follow-up grant to be
+                    incorporated as a non-profit organization and step up their activities. [
+                    <a href="https://arxiv.org/abs/2010.13552">arXiv</a>]
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To the team at
+                    <a class="recipient-link" href="https://www.qubitbyqubit.org/">Qubit By Qubit</a>, to develop
+                    courses and materials to educate a diverse ecosystem of open source quantum contributors.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To Pedro Rivero Ramírez for
+                    <a class="recipient-link" href="https://github.com/pedrorrivero/qrand/">QRand</a>, a multi-platform
+                    quantum random number generator library integrated with numpy.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="http://jemisjoky.com/">Jacob Miller</a>
+                    for a PyTorch toolbox for matrix product state models.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://rochisha0.github.io/">Rochisha Agarwal</a>
+                    and
+                    <a class="recipient-link" href="https://www.linkedin.com/in/natanshmathur/">Natansh Mathur</a>
+                    to create a
+                    <a href="https://github.com/Quantum-Machine-Learning-Textbook/Book">Machine Learning Textbook</a>
+                    with integrated code and visualization.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://markcunningham.tech/">Mark Cunningham</a>
+                    to explore applications of quantum computing to medical imaging.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://github.com/splch">Spencer Churchill</a>
+                    to write
+                    <a href="https://quantumtales.org">Quantum Tales</a>, a series of fairy tales where quantum
+                    algorithms are applied to resolve their conflicts.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://scholar.google.com/citations?user=6CORrpcAAAAJ&hl=en"
+                      >Daniel Tan</a
+                    >
+                    to develop and open source the Optimal Layout Synthesizer for Quantum Computing, OLSQ. This compiler
+                    beats other benchmarks on optimal layout of computational qubits onto physical qubits. [
+                    <a href="https://arxiv.org/abs/2007.15671">arXiv</a>] [
+                    <a href="https://arxiv.org/abs/2002.09783">arXiv</a>]
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://www.linkedin.com/in/lia-yeh">Lia Yeh</a>
+                    and the
+                    <a class="recipient-link" href="https://fullstackquantumcomputation.tech/"
+                      >fullstackquantumcomputation.tech</a
+                    >
+                    team to build community-driven open-source educational resources for quantum computing. [
+                    <a href="https://fullstackquantumcomputation.tech/">site</a>] [
+                    <a href="https://discord.com/invite/NDm9e9W">discord</a>]
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="http://glassnotes.github.io/">Olivia De Matteo</a>
+                    and
+                    <a class="recipient-link" href="https://www.sckaiser.com/">Sarah Kaiser</a>
+                    to build and optimize an open source Q# library for quantum RAM. [
+                    <a href="https://github.com/qsharp-community/qram">github</a>]
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://rogerluo.me/">Roger Luo</a>
+                    to continue the development of
+                    <a href="https://yaoquantum.org/">Yao.jl</a>, a software for solving practical problems in quantum
+                    computation research. The grant will support Yao's new
+                    <a href="https://github.com/QuantumBFS/YaoLang.jl">DSL compiler development</a>, which includes an
+                    extensible DSL infrastructure, Julia-based frontend, Julia AST and QASM code generator, and a
+                    quantum circuit simplification infrastructure based on pattern matching. [
+                    <a href="https://github.com/QuantumBFS/YaoLang.jl">github</a>]
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://watermarkhu.nl/">Mark Shui Hu</a>
+                    to further develop
+                    <a href="https://github.com/watermarkhu/qsurface"> Qsurface</a>, a simulator package for surface
+                    codes. The grant will improve visualization methods and facilitate the collaboration of an open,
+                    modular platform for surface code simulations. [
+                    <a href="https://github.com/watermarkhu/qsurface">github</a>] [
+                    <a href="https://qsurface.readthedocs.io/en/latest/index.html">Docs</a>]
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://github.com/usmanmunara/">Muhammad Usman Farooq</a>
+                    for a research internship in the
+                    <a href="http://penghuiyao.info/">Yao group</a> that lost funding due to the COVID crisis. They aim
+                    to construct a quantum channel with a Classical input Reverse Information Cost of zero.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://dlasecki.github.io/">Dariusz Lasecki</a>
+                    to build an open source QAOA library and examples using Q#.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://scholar.google.ca/citations?user=k9O1vSwAAAAJ&hl=en"
+                      >Stephen DiAdamo</a
+                    >
+                    to develop
+                    <a href="https://arxiv.org/abs/2003.06397">QuNetSim</a>, a quantum network Python simulation
+                    framework for investigating quantum network protocols. [
+                    <a href="https://github.com/tqsd/QuNetSim">github</a>] [
+                    <a href="https://arxiv.org/abs/2003.06397">arXiv</a>] [
+                    <a href="https://www.youtube.com/watch?v=HE6jWjW1WT8">video</a>]
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://vprusso.github.io/">Vincent Russo</a>
+                    to support
+                    <a href="https://vprusso.github.io/toqito/">toqito</a>, an open source Python toolkit for quantum
+                    information theory with extra functionality to study non-local games. [
+                    <a href="https://github.com/vprusso/toqito">software</a>] [<a
+                      href="https://joss.theoj.org/papers/10.21105/joss.03082"
+                      >paper</a
+                    >] [<a href="https://www.youtube.com/watch?v=6R7qSszJwBI">video</a>]
+                  </p>
+                </li>
+              </ul>
 
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To the
-                                    <a class="recipient-link" href="https://qworld.lu.lv/">QWorld</a>, team, a follow-up grant to be incorporated as a non-profit organization and step up their activities. [
-                                    <a href="https://arxiv.org/abs/2010.13552">arXiv</a>]
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To the team at
-                                    <a class="recipient-link" href="https://www.qubitbyqubit.org/">Qubit By Qubit</a>, to develop courses and materials to educate a diverse ecosystem of open source quantum contributors.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To Pedro Rivero Ramírez for
-                                    <a class="recipient-link" href="https://github.com/pedrorrivero/qrand/">QRand</a>, a multi-platform quantum random number generator library integrated with numpy.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="http://jemisjoky.com/">Jacob Miller</a> for a PyTorch toolbox for matrix product state models.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://rochisha0.github.io/">Rochisha
-                                        Agarwal</a> and <a class="recipient-link" href="https://www.linkedin.com/in/natanshmathur/">Natansh Mathur</a> to create a <a href="https://github.com/Quantum-Machine-Learning-Textbook/Book">Machine Learning Textbook</a>                                    with integrated code and visualization.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://markcunningham.tech/">Mark Cunningham</a> to explore applications of quantum computing to medical imaging.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://github.com/splch">Spencer Churchill</a> to write
-                                    <a href="https://quantumtales.org">Quantum Tales</a>, a series of fairy tales where quantum algorithms are applied to resolve their conflicts.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://scholar.google.com/citations?user=6CORrpcAAAAJ&hl=en">Daniel
-                                        Tan</a> to develop and open source the Optimal Layout Synthesizer for Quantum Computing, OLSQ. This compiler beats other benchmarks on optimal layout of computational qubits onto physical qubits. [
-                                    <a href="https://arxiv.org/abs/2007.15671">arXiv</a>] [
-                                    <a href="https://arxiv.org/abs/2002.09783">arXiv</a>]
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://www.linkedin.com/in/lia-yeh">Lia Yeh</a> and the
-                                    <a class="recipient-link" href="https://fullstackquantumcomputation.tech/">fullstackquantumcomputation.tech</a> team to build community-driven open-source educational resources for quantum computing. [
-                                    <a href="https://fullstackquantumcomputation.tech/">site</a>] [
-                                    <a href="https://discord.com/invite/NDm9e9W">discord</a>]
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="http://glassnotes.github.io/">Olivia De
-                                        Matteo</a> and
-                                    <a class="recipient-link" href="https://www.sckaiser.com/">Sarah Kaiser</a> to build and optimize an open source Q# library for quantum RAM. [
-                                    <a href="https://github.com/qsharp-community/qram">github</a>]
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://rogerluo.me/">Roger Luo</a> to continue the development of <a href="https://yaoquantum.org/">Yao.jl</a>, a software for solving practical problems in quantum computation research.
-                                    The grant will support Yao's new <a href="https://github.com/QuantumBFS/YaoLang.jl">DSL compiler
-                                        development</a>, which includes an extensible DSL infrastructure, Julia-based frontend, Julia AST and QASM code generator, and a quantum circuit simplification infrastructure based on pattern matching. [
-                                    <a href="https://github.com/QuantumBFS/YaoLang.jl">github</a>]
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://watermarkhu.nl/">Mark Shui
-                                        Hu</a> to further develop <a href="https://github.com/watermarkhu/qsurface">
-                                        Qsurface</a>, a simulator package for surface codes. The grant will improve visualization methods and facilitate the collaboration of an open, modular platform for surface code simulations. [
-                                    <a href="https://github.com/watermarkhu/qsurface">github</a>] [
-                                    <a href="https://qsurface.readthedocs.io/en/latest/index.html">Docs</a>]
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://github.com/usmanmunara/">Muhammad Usman
-                                        Farooq</a> for a research internship in the
-                                    <a href="http://penghuiyao.info/">Yao group</a> that lost funding due to the COVID crisis. They aim to construct a quantum channel with a Classical input Reverse Information Cost of zero.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://dlasecki.github.io/">Dariusz Lasecki</a> to build an open source QAOA library and examples using Q#.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://scholar.google.ca/citations?user=k9O1vSwAAAAJ&hl=en">Stephen
-                                        DiAdamo</a> to develop <a href="https://arxiv.org/abs/2003.06397">QuNetSim</a>, a quantum network Python simulation framework for investigating quantum network protocols. [
-                                    <a href="https://github.com/tqsd/QuNetSim">github</a>] [
-                                    <a href="https://arxiv.org/abs/2003.06397">arXiv</a>] [
-                                    <a href="https://www.youtube.com/watch?v=HE6jWjW1WT8">video</a>]
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://vprusso.github.io/">Vincent Russo</a> to support
-                                    <a href="https://vprusso.github.io/toqito/">toqito</a>, an open source Python toolkit for quantum information theory with extra functionality to study non-local games. [
-                                    <a href="https://github.com/vprusso/toqito">software</a>]
-                                    [<a href="https://joss.theoj.org/papers/10.21105/joss.03082">paper</a>]
-                                    [<a href="https://www.youtube.com/watch?v=6R7qSszJwBI">video</a>]
-                                </p>
-                            </li>
-                        </ul>
+              <h4 class="grant-year">2019 Grants</h4>
+              <ul class="grant-list">
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="http://jankiewiczstudio.com/">Klementyna Jankiewicz</a>
+                    and
+                    <a class="recipient-link" href="https://p.migdal.pl/">Piotr Migdal</a>
+                    to develop widgets that embed
+                    <a href="https://github.com/Quantum-Game/bra-ket-vue"> visualizations of quantum states and ops </a>
+                    into blog posts, interactive textbooks, and explorable explanations. These are extensions from their
+                    work on a new version of
+                    <a href="http://quantumgame.io/">QuantumGame</a>. [
+                    <a href="https://github.com/stared/quantum-game-2">QuantumGame - Github</a>] [
+                    <a href="https://github.com/Quantum-Game/bra-ket-vue">Bra-Ket-Vue - Github</a>]
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://www.linkedin.com/in/abdulko/">Abdul Karim Obeid</a>
+                    and the
+                    <a class="recipient-link" href="https://qhyp.info/">QHyp</a>
+                    project, developing research and software at the intersection of quantum contextuality and
+                    probabilistic programming. [
+                    <a href="https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0208555">Publication</a>]
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://github.com/vm6502q/qrack">Qrack</a>
+                    an open source, comprehensive, GPU-accelerated framework for simulating universal quantum
+                    processors. (Qrack has also passed the proof-of-concept stage for distributed simulation.) [
+                    <a href="https://qrack.readthedocs.io/en/latest/index.html">Docs</a>] [
+                    <a href="https://qrack.readthedocs.io/en/latest/performance.html">Benchmarks</a>]
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://scholar.google.com/citations?user=WmghO7UAAAAJ"
+                      >Alexandru Paler</a
+                    >
+                    and
+                    <a class="recipient-link" href="https://scholar.google.com/citations?user=80srjkkAAAAJ&hl=en"
+                      >Daniel Herr</a
+                    >
+                    to develop zxQentiana an open source, resource estimator for time and space tradeoffs for the
+                    surface code that uses pyZX compilation. [
+                    <a href="https://github.com/quantumresource/zxQentiana">github</a>]
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="http://qworld.lu.lv/index.php/qcousins/">QCousins</a>
+                    to support their mission of welcoming a young and diverse group of programmers into quantum
+                    computing. The grant will fund more of their quantum programming
+                    <a href="http://qworld.lu.lv/index.php/workshop-bronze/">workshops</a>
+                    and
+                    <a href="http://qworld.lu.lv/index.php/qkitchen/">educational materials</a>. [
+                    <a href="http://qworld.lu.lv/index.php/unitary-fund/">Workshops we funded</a>]
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://www.scigym.net/">SciGym</a>
+                    to build open source library for reinforcement learning environments in science. Examples include
+                    <a href="https://www.scigym.net/env/gym-surfacecode">training a surface code decoder.</a>
+                  </p>
+                </li>
+              </ul>
 
-                        <h4 class="grant-year">2019 Grants</h4>
-                        <ul class="grant-list">
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="http://jankiewiczstudio.com/">Klementyna
-                                        Jankiewicz</a> and
-                                    <a class="recipient-link" href="https://p.migdal.pl/">Piotr Migdal</a> to develop widgets that embed
-                                    <a href="https://github.com/Quantum-Game/bra-ket-vue">
-                                        visualizations of quantum states and ops </a> into blog posts, interactive textbooks, and explorable explanations. These are extensions from their work on a new version of
-                                    <a href="http://quantumgame.io/">QuantumGame</a>. [
-                                    <a href="https://github.com/stared/quantum-game-2">QuantumGame - Github</a>] [
-                                    <a href="https://github.com/Quantum-Game/bra-ket-vue">Bra-Ket-Vue - Github</a>]
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://www.linkedin.com/in/abdulko/">Abdul Karim
-                                        Obeid</a> and the <a class="recipient-link" href="https://qhyp.info/">QHyp</a> project, developing research and software at the intersection of quantum contextuality and probabilistic programming. [
-                                    <a href="https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0208555">Publication</a>]
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://github.com/vm6502q/qrack">Qrack</a> an open source, comprehensive, GPU-accelerated framework for simulating universal quantum processors. (Qrack has also passed the proof-of-concept stage for distributed simulation.) [
-                                    <a href="https://qrack.readthedocs.io/en/latest/index.html">Docs</a>] [
-                                    <a href="https://qrack.readthedocs.io/en/latest/performance.html">Benchmarks</a>]
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://scholar.google.com/citations?user=WmghO7UAAAAJ">Alexandru
-                                        Paler</a> and
-                                    <a class="recipient-link" href="https://scholar.google.com/citations?user=80srjkkAAAAJ&hl=en">Daniel
-                                        Herr</a> to develop zxQentiana an open source, resource estimator for time and space tradeoffs for the surface code that uses pyZX compilation. [
-                                    <a href="https://github.com/quantumresource/zxQentiana">github</a>]
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="http://qworld.lu.lv/index.php/qcousins/">QCousins</a> to support their mission of welcoming a young and diverse group of programmers into quantum computing. The grant will fund more
-                                    of their quantum programming <a href="http://qworld.lu.lv/index.php/workshop-bronze/">workshops</a> and <a href="http://qworld.lu.lv/index.php/qkitchen/">educational materials</a>. [
-                                    <a href="http://qworld.lu.lv/index.php/unitary-fund/">Workshops we funded</a>]
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://www.scigym.net/">SciGym</a> to build open source library for reinforcement learning environments in science. Examples include
-                                    <a href="https://www.scigym.net/env/gym-surfacecode">training a surface code
-                                        decoder.</a>
-                                </p>
-                            </li>
-                        </ul>
+              <h4 class="grant-year">2018 Grants</h4>
+              <ul class="grant-list">
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="http://www.gate42.org/">Gate42</a>
+                    to build an open source library for quantum error mitigation and dynamical decoupling: both
+                    techniques for compiling programs to reduce the effect of noise in quantum processors.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To the
+                    <a href="https://github.com/QuantumAI-lib/NISQAI">NISQAI</a>
+                    project to build a library for machine learning with near-term quantum processors.
+                    <a href="https://github.com/QuantumAI-lib/NISQAI/blob/master/proposal/nisqai.pdf">[Proposal]</a>
+                    <a href="https://www.youtube.com/watch?v=_dOJ7Bhibec&t=1s">[Video]</a>
+                    <a href="https://scirate.com/arxiv/2003.01695">[arXiv]</a>
+                    <a href="https://link.aps.org/doi/10.1103/PhysRevA.102.032420">[publ.]</a>
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://github.com/perak">Petar Korponaić</a>
+                    to support and extend the
+                    <a href="https://quantum-circuit.com/home">Quantum Programming Studio</a>, an open source in-browser
+                    IDE for multi-platform quantum programming. This project became the startup
+                    <a href="https://quantastica.com/">Quantastica</a> that makes cross-platform quantum software.
+                    <a href="https://twitter.com/quantcirc">[Twitter]</a>
+                    <a href="https://quantum-circuit.com/">[Website]</a>
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://github.com/LSaldyt">Lucas Saldyt</a>
+                    to prototype a
+                    <a href="https://github.com/LSaldyt/unitary-proposal">
+                      probabilistic programming language for quantum computing</a
+                    >. This library is called <a href="https://github.com/LSaldyt/qurry">Qurry</a>.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://www.cs.ru.nl/A.Kissinger/">Aleks Kissinger</a>
+                    and
+                    <a href="http://vdwetering.name/">John van de Wetering</a>
+                    to support the development of
+                    <a href="https://github.com/Quantomatic/pyzx">pyZX</a>, an optimizing quantum circuit compiler based
+                    on a diagrammatic semantics from monoidal categories. This work resulted in two publications: (i) an
+                    overview of the pyZX library and (ii) benchmarks showing that pyZX outperforms the state of the art
+                    in reducing T-Count.
+                    <a href="https://arxiv.org/abs/1904.04735">[arXiv1]</a>
+                    <a href="https://arxiv.org/pdf/1903.10477.pdf">[arXiv2]</a>
+                    <a href="https://www.youtube.com/watch?v=iC-KVdB8pf0">[Video]</a>
+                    <a href="http://zxcalculus.com/">[Website]</a>
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://adamisntdead.com/">Adam Kelly</a>
+                    to extend his work on the open source
+                    <a href="https://qcgpu.github.io/">QCGPU</a> high performance quantum circuit simulator [
+                    <a href="https://github.com/QCGPU/qcgpu">github</a>] [
+                    <a href="https://github.com/libtangle">libraries</a>] [
+                    <a href="https://libtangle.com/">website</a>].
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://github.com/ntwalibas" target="_blank">Ntwali Bashige</a>
+                    to develop the
+                    <a href="https://github.com/ntwalibas/unitary-proposal" target="_blank">Avalon</a>
+                    quantum programming language and quantum programming communities in India and D. R. Congo.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="http://www.mustythoughts.com/about/" target="_blank"
+                      >Michał Stęchły</a
+                    >
+                    to build a traveling salesman solver web application and
+                    <a class="recipient-link" href="https://github.com/mstechly/quantum_tsp_tutorials">tutorials</a>
+                    for Forest based on the quantum approximate optimization algorithm.
+                    <a href="https://github.com/mstechly/quantum_tsp_tutorials">[github tutorials]</a>
+                    <a
+                      href="https://www.mustythoughts.com/post/solving-the-traveling-salesman-problem-using-quantum-computer"
+                      >[blogpost]</a
+                    >
+                    <a href="https://github.com/BOHRTECHNOLOGY/tsp-demo-unitary-fund"
+                      >[web app source code (it's not live anymore)]</a
+                    >
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" />
+                  <p>
+                    To
+                    <a class="recipient-link" href="https://twitter.com/charl_bp" target="_blank">
+                      Carlos Bravo Prieto
+                    </a>
+                    to implement the Adiabatically Assisted Variational Quantum Eigensolvers in Forest, a hybrid
+                    classical-quantum algorithm for solving optimization problems.
+                    <a href="https://github.com/bpcarlos/AAVQE-Tutorial" target="_blank">[github tutorial]</a>
+                    <a href="https://arxiv.org/abs/2002.06210" target="_blank">[arXiv]</a>
+                    <a href="https://quantum-journal.org/papers/q-2020-05-28-272/" target="_blank">[publication]</a>
+                  </p>
+                </li>
+              </ul>
 
-                        <h4 class="grant-year">2018 Grants</h4>
-                        <ul class="grant-list">
-                        <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="http://www.gate42.org/">Gate42</a> to build an open source library for quantum error mitigation and dynamical decoupling: both techniques for compiling programs to reduce the effect
-                                    of noise in quantum processors.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To the <a href="https://github.com/QuantumAI-lib/NISQAI">NISQAI</a> project to build a library for machine learning with near-term quantum processors.
-                                    <a href="https://github.com/QuantumAI-lib/NISQAI/blob/master/proposal/nisqai.pdf">[Proposal]</a>
-                                    <a href="https://www.youtube.com/watch?v=_dOJ7Bhibec&t=1s">[Video]</a>
-                                    <a href="https://scirate.com/arxiv/2003.01695">[arXiv]</a>
-                                    <a href="https://link.aps.org/doi/10.1103/PhysRevA.102.032420">[publ.]</a>
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://github.com/perak">Petar Korponaić</a> to support and extend the
-                                    <a href="https://quantum-circuit.com/home">Quantum Programming Studio</a>, an open source in-browser IDE for multi-platform quantum programming. This project became the startup
-                                    <a href="https://quantastica.com/">Quantastica</a> that makes cross-platform quantum software.
-                                    <a href="https://twitter.com/quantcirc">[Twitter]</a>
-                                    <a href="https://quantum-circuit.com/">[Website]</a>
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://github.com/LSaldyt">Lucas Saldyt</a> to prototype a
-                                    <a href="https://github.com/LSaldyt/unitary-proposal">
-                                        probabilistic programming language for quantum computing</a>. This library is called
-                                    <a href="https://github.com/LSaldyt/qurry">Qurry</a>.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://www.cs.ru.nl/A.Kissinger/">Aleks
-                                        Kissinger</a> and
-                                    <a href="http://vdwetering.name/">John van de Wetering</a> to support the development of
-                                    <a href="https://github.com/Quantomatic/pyzx">pyZX</a>, an optimizing quantum circuit compiler based on a diagrammatic semantics from monoidal categories. This work resulted in two publications: (i) an overview of the
-                                    pyZX library and (ii) benchmarks showing that pyZX outperforms the state of the art in reducing T-Count.
-                                    <a href="https://arxiv.org/abs/1904.04735">[arXiv1]</a>
-                                    <a href="https://arxiv.org/pdf/1903.10477.pdf">[arXiv2]</a>
-                                    <a href="https://www.youtube.com/watch?v=iC-KVdB8pf0">[Video]</a>
-                                    <a href="http://zxcalculus.com/">[Website]</a>
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://adamisntdead.com/">Adam Kelly</a> to extend his work on the open source
-                                    <a href="https://qcgpu.github.io/">QCGPU</a> high performance quantum circuit simulator [
-                                    <a href="https://github.com/QCGPU/qcgpu">github</a>] [
-                                    <a href="https://github.com/libtangle">libraries</a>] [
-                                    <a href="https://libtangle.com/">website</a>].
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://github.com/ntwalibas" target="_blank">Ntwali Bashige</a> to develop the
-                                    <a href="https://github.com/ntwalibas/unitary-proposal" target="_blank">Avalon</a> quantum programming language and quantum programming communities in India and D. R. Congo.
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="http://www.mustythoughts.com/about/" target="_blank">Michał Stęchły</a> to build a traveling salesman solver web application and <a class="recipient-link" href="https://github.com/mstechly/quantum_tsp_tutorials">tutorials</a>                                    for Forest based on the quantum approximate optimization algorithm.
-                                    <a href="https://github.com/mstechly/quantum_tsp_tutorials">[github tutorials]</a>
-                                    <a href="https://www.mustythoughts.com/post/solving-the-traveling-salesman-problem-using-quantum-computer">[blogpost]</a>
-                                    <a href="https://github.com/BOHRTECHNOLOGY/tsp-demo-unitary-fund">[web app source
-                                        code (it's not live anymore)]</a>
-
-                                </p>
-                            </li>
-                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" />
-                                <p>
-                                    To <a class="recipient-link" href="https://twitter.com/charl_bp" target="_blank">
-                                        Carlos Bravo Prieto </a> to implement the Adiabatically Assisted Variational Quantum Eigensolvers in Forest, a hybrid classical-quantum algorithm for solving optimization problems.
-                                    <a href="https://github.com/bpcarlos/AAVQE-Tutorial" target="_blank">[github
-                                        tutorial]</a>
-                                    <a href="https://arxiv.org/abs/2002.06210" target="_blank">[arXiv]</a>
-                                    <a href="https://quantum-journal.org/papers/q-2020-05-28-272/" target="_blank">[publication]</a>
-                                </p>
-                            </li>
-                        </ul>
-
-                        <footer class="footer leading-arrow light-arrow">
-                            This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
-                                of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request!
-                            <br>
-                            <br>
-                            <table>
-                                <tr>
-                                    <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                                class="fa fa-twitter"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                                class="fa fa-twitch"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                                class="fa fa-youtube"></i></a></th>
-                                    <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                                class="fab fa-discord"></i></a></th>
-                                </tr>
-                            </table> &copy;2020 Unitary Fund
-                        </footer>
-                    </div>
-                    <div class="col-1" id="menu-container">
-                        <table style="width:auto; margin-right:0px; margin-left: auto;">
-                            <tr>
-                                <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                            class="fa fa-twitter"></i></a></th>
-                                <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                            class="fa fa-twitch"></i></a></th>
-                                <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                            class="fa fa-youtube"></i></a></th>
-                                <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                            class="fab fa-discord"></i></a></th>
-                            </tr>
-                        </table>
-                        <p class="light" id="menu">
-                            <a href="grants.html" class="active">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                    <div id="mobile-menu-container">
-                        <p class="light" id="mobile-menu">
-                            <a href="grants.html" class="active">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                </div>
-            </section>
-        </main>
+              <footer class="footer leading-arrow light-arrow">
+                This website is hosted on
+                <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community
+                follows this
+                <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a
+                >. <br />
+                <br />
+                If you have suggestions for changes then please open up a pull request!
+                <br />
+                <br />
+                <table>
+                  <tr>
+                    <th style="text-align: right">
+                      <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"
+                        ><i class="fa fa-youtube"></i
+                      ></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                    </th>
+                  </tr>
+                </table>
+                &copy;2020 Unitary Fund
+              </footer>
+            </div>
+            <div class="col-1" id="menu-container">
+              <table style="width: auto; margin-right: 0px; margin-left: auto">
+                <tr>
+                  <th style="text-align: right">
+                    <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                  </th>
+                </tr>
+              </table>
+              <p class="light" id="menu">
+                <a href="grants.html" class="active">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+            <div id="mobile-menu-container">
+              <p class="light" id="mobile-menu">
+                <a href="grants.html" class="active">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
     <script>
-        var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
-        mobileMenuContainer = document.querySelector("#mobile-menu-container");
-        mobileMenuIcon.addEventListener("click", function() {
-            mobileMenuIcon.classList.toggle("is-active");
-            mobileMenuContainer.classList.toggle("active");
-        });
+      var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
+      mobileMenuContainer = document.querySelector("#mobile-menu-container")
+      mobileMenuIcon.addEventListener("click", function () {
+        mobileMenuIcon.classList.toggle("is-active")
+        mobileMenuContainer.classList.toggle("active")
+      })
     </script>
-</body>
-
+  </body>
 </html>

--- a/grants.html
+++ b/grants.html
@@ -53,7 +53,7 @@
                 <div class="container">
                     <div class="col-3">
                         <div class="hero">
-                            <a href="/"><img src="/logos/logov3.svg" alt="Unitary Fund" /></a>
+                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
                             <p class="tagline"><b>Because evolution is
                                     <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
                                         target="_blank">unitary</a></b>.</p>
@@ -77,103 +77,103 @@
                         <h4>2022 Grants</h4> 
                         <br>
                            <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" id="homl" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" id="homl" />
                                 <p>
                                     To <a class="recipient-link" href="https://steventhomson.co.uk/">Steven Thomson</a>, to create <a href="https://www.insidequantum.org">Inside Quantum</a>, a new quantum technology themed podcast focusing on the people behind the research, aimed at showcasing a diverse range of voices in order to promote inclusivity and inspire the next generation of quantum technologists. </p>
-                            </li><br>                        
+                            </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" id="homl" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" id="homl" />
                                 <p>
                                     To <a class="recipient-link" href="https://twitter.com/atamb_">Ayush Tambde</a>, to develop a Higher-Level Oracle Description Language (HOML), so that the compiler can interoperate with other frameworks/languages (OpenQASM, QIR). [<a href="https://arxiv.org/abs/2110.12487
 ">arXiv</a>]                               </p>
-                            </li><br>                        
+                            </li><br>
                             <h4>2021 Grants</h4>
                         <br>
                            <li>
 
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" id="2qan" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" id="2qan" />
                                 <p>
                                     To <a class="recipient-link" href="https://twitter.com/719lingling">Lingling Lao</a>, to develop 2QAN, a compiler that optimizes quantum circuits for 2-local qubit Hamiltonian simulation problems. [<a href="https://arxiv.org/abs/2108.02099
 ">arXiv</a>]                               </p>
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" id="qutip-vqa" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" id="qutip-vqa" />
                                 <p>
                                     To <a class="recipient-link" href="https://benbraham.com">Ben Braham</a>, to develop a framework to define and run variational quantum algorithms in QuTiP, leveraging quantum optimal control to parametrize control pulses.
                                </p>
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" id="qudit-simulator" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" id="qudit-simulator" />
                                 <p>
                                     To <a class="recipient-link" href="https://twitter.com/rmjh94">Hoang Van Do</a>, <a class="recipient-link" href="http://www.normalesup.org/~gouzien/">Elie Gouzien</a>, and <a class="recipient-link" href="https://twitter.com/saesunkim">Saesun Kim</a> to develop a Heisenberg-picture simulator and universal gate set for high dimensional systems.
                                </p>
                             </li><br>
 
                            <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" id="qworld" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" id="qworld" />
                                 <p>
                                     To Abuzer Yakaryilmaz and the <a href="https://twitter.com/qworld19">QWorld</a> team to organize <a class="recipient-link" href="https://qworld.net/qcourse511-1/">QCourse511</a>, a graduate-level online course on quantum computing and programming.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" id="lattice-surgery" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" id="lattice-surgery" />
                                 <p>
                                     To <b>George Watkins</b>, <b>Alex Nguyen</b>, <b>Varun Seshadri</b>, and <b>Keelan Watkins</b> to further develop a <a class="recipient-link" href="https://github.com/latticesurgery-com/lattice-surgery-compiler">lattice-surgery-based</a> quantum error correction compiler. [Demo at <a href="https://latticesurgery.com/">latticesurgery.com</a>]
                                 </p>
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" id="qdot" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" id="qdot" />
                                 <p>
                                     To <b>Brian Shi</b> to build <a href="https://github.com/brs96/Qdot">Qdot</a>, a Scala 3 library (QASM-transpiler) that allows Scala/Java developers write native quantum/hybrid programs.
                                 </p>
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" id="oqupy" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" id="oqupy" />
                                 <p>
                                     To <a class="recipient-link" href="https://twitter.com/fuxgerald">Gerald E. Fux</a> and Dominic Gribben and the <a class="recipient-link" href="https://github.com/tempoCollaboration/TimeEvolvingMPO">TEMPO collaboration</a> to develop an open source python package for simulating non-Markovian open quantum systems using tensor network techniques. In particular, the grant will enable adding two new features: studying the role of environment correlation functions through observables of the system and of multiple environments coupled to a single system.
                                 </p>
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" id="qleet" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" id="qleet" />
                                 <p>
                                     To <a class="recipient-link" href="https://obliviateandsurrender.github.io">Utkarsh Azad</a> and <a class="recipient-link" href="https://researchweb.iiit.ac.in/~animesh.sinha/home">Animesh Sinha</a> to build a visualization
                                     tool called <a class="recipient-link" href="https://github.com/QLemma/qLEET">qLEET</a> for exploring loss landscapes, expressibility, entangling capacity and trainability for noisy, parameterized quantum circuits.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://www.linkedin.com/in/danny-samuel-9a8a621ba/">Danny Samuel</a> to improve and extend the performance of variational quantum algorithms with error mitigation, benchmarking them
                                     with mirror circuits.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To Lorenzo Buffoni, to develop <a class="recipient-link" href="https://github.com/Buffoni/SQWalk">SQWalk</a>, A Stochastic Quantum Walk simulator based on QuTiP.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To Jonas Schwab and the ALF collaboration, to develop <a class="recipient-link" href="https://git.physik.uni-wuerzburg.de/ALF/pyALF">pyALF</a>, the Python interface of the ALF project, a powerful and flexible package
                                     for Quantum Monte Carlo simulations of fermion systems.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To the teams at Orange Quantum Systems and Qblox, to develop <a class="recipient-link" href="https://quantify-quantify-core.readthedocs-hosted.com/en/stable/">Quantify Core</a>, an open-source Python-based data acquisition
                                     and experiment control platform for quantum computing and solid-state physics experiments. It is built on <a href="https://qcodes.github.io/Qcodes/">QCoDeS</a> and is a spiritual successor of <a href="https://github.com/DiCarloLab-Delft/PycQED_py3">PycQED</a>.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To Diego Ariel Wisniacki, Martin Larocca, Emiliano Manuel Fortes, Julian Matias Ruffinelli to develop Krylov evolution algorithms integrated with QuTiP.
                                     [<a href="https://arxiv.org/abs/2010.03598">K-GRAPE</a>, <a href="https://arxiv.org/abs/2107.09805">Krylov-Loschmidt</a>].
@@ -183,14 +183,14 @@
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To Reem Larabi to add more visualization improvements to the %debug tool in Q# by expanding its current set of controls.
                                 </p>
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To Alessandro Luongo and Armando Bellante to develop <a class="recipient-link" href="https://quantumalgorithms.org">Quantumalgorithms.org</a> an open-source web book collecting in an organized manner lectures notes
                                     around quantum algorithms for information processing, data analysis and machine learning.
@@ -198,7 +198,7 @@
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://github.com/xvzcf">Goutam Tamvada</a> and
                                     <a class="recipient-link" href="https://www.douglas.stebila.ca/">Douglas Stebila</a> to develop VeriFrodo, an open-source package implementing a lattice-based quantum-resistant cryptographic algorithms in Jasmin within
@@ -210,7 +210,7 @@
 
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://github.com/lockwo">Owen Lockwood</a> to develop a software package using classical deep reinforcement learning to improve quantum optimization, both for quantum simulations
                                     and hardware integration.
@@ -218,7 +218,7 @@
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://twitter.com/dsfranca">Daniel Stilck
                                         França</a> to develop a software package that will help benchmark the limitations of noisy quantum devices for solving optimization problems. [<a href="https://arxiv.org/pdf/2009.05532.pdf">arXiv</a>] [<a href="https://www.youtube.com/watch?v=00ULKjGu1-A">QIP talk on the
@@ -227,7 +227,7 @@
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://twitter.com/RheaParekh1">Rhea Parekh</a> and <a class="recipient-link" href="https://scholar.google.ca/citations?user=k9O1vSwAAAAJ&hl=en">Stephen
                                         DiAdamo</a> to further develop <a class="recipient-link" href="https://github.com/Interlin-q/Interlin-q/">Interlin-q</a>, a distributed quantum-enabled simulator integrated with QuNetSim. [<a href="https://arxiv.org/abs/2106.06841">arXiv</a>]
@@ -237,7 +237,7 @@
                         <h4>2020 Grants</h4>
                         <br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://dlasecki.github.io/">Dariusz Lasecki</a> to build an open-source Python library that delivers easy-to-use high-quality pre-trained machine learning models to predict good QAOA
                                     starting parameters for selected classes of problems.
@@ -245,7 +245,7 @@
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To Oscar Higgott, to continue developing and maintaining <a class="recipient-link" href="https://github.com/oscarhiggott/PyMatching">PyMatching</a>, a Python package for decoding quantum error correcting codes with
                                     minimum-weight perfect matching (MWPM). [<a href="https://arxiv.org/abs/2105.13082">arXiv</a>]
@@ -253,7 +253,7 @@
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To Nicola Mosco, to develop <a class="recipient-link" href="https://gitlab.com/homodyne-ct/MartaCT.jl">Marta CT</a>, a software package in Julia for medical diagnostics that uses a quantum-tomography-inspired technique
                                     for state reconstruction in order to reduce the radiation dose patients receive. [<a href="https://arxiv.org/abs/2106.12353">arXiv</a>]
@@ -261,7 +261,7 @@
                             </li><br>
 
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To the
                                     <a class="recipient-link" href="https://qworld.lu.lv/">QWorld</a>, team, a follow-up grant to be incorporated as a non-profit organization and step up their activities. [
@@ -269,47 +269,47 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To the team at
                                     <a class="recipient-link" href="https://www.qubitbyqubit.org/">Qubit By Qubit</a>, to develop courses and materials to educate a diverse ecosystem of open source quantum contributors.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To Pedro Rivero Ramírez for
                                     <a class="recipient-link" href="https://github.com/pedrorrivero/qrand/">QRand</a>, a multi-platform quantum random number generator library integrated with numpy.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="http://jemisjoky.com/">Jacob Miller</a> for a PyTorch toolbox for matrix product state models.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://rochisha0.github.io/">Rochisha
                                         Agarwal</a> and <a class="recipient-link" href="https://www.linkedin.com/in/natanshmathur/">Natansh Mathur</a> to create a <a href="https://github.com/Quantum-Machine-Learning-Textbook/Book">Machine Learning Textbook</a>                                    with integrated code and visualization.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://markcunningham.tech/">Mark Cunningham</a> to explore applications of quantum computing to medical imaging.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://github.com/splch">Spencer Churchill</a> to write
                                     <a href="https://quantumtales.org">Quantum Tales</a>, a series of fairy tales where quantum algorithms are applied to resolve their conflicts.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://scholar.google.com/citations?user=6CORrpcAAAAJ&hl=en">Daniel
                                         Tan</a> to develop and open source the Optimal Layout Synthesizer for Quantum Computing, OLSQ. This compiler beats other benchmarks on optimal layout of computational qubits onto physical qubits. [
@@ -318,7 +318,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://www.linkedin.com/in/lia-yeh">Lia Yeh</a> and the
                                     <a class="recipient-link" href="https://fullstackquantumcomputation.tech/">fullstackquantumcomputation.tech</a> team to build community-driven open-source educational resources for quantum computing. [
@@ -327,7 +327,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="http://glassnotes.github.io/">Olivia De
                                         Matteo</a> and
@@ -336,7 +336,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://rogerluo.me/">Roger Luo</a> to continue the development of <a href="https://yaoquantum.org/">Yao.jl</a>, a software for solving practical problems in quantum computation research.
                                     The grant will support Yao's new <a href="https://github.com/QuantumBFS/YaoLang.jl">DSL compiler
@@ -345,7 +345,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://watermarkhu.nl/">Mark Shui
                                         Hu</a> to further develop <a href="https://github.com/watermarkhu/qsurface">
@@ -355,7 +355,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://github.com/usmanmunara/">Muhammad Usman
                                         Farooq</a> for a research internship in the
@@ -363,13 +363,13 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://dlasecki.github.io/">Dariusz Lasecki</a> to build an open source QAOA library and examples using Q#.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://scholar.google.ca/citations?user=k9O1vSwAAAAJ&hl=en">Stephen
                                         DiAdamo</a> to develop <a href="https://arxiv.org/abs/2003.06397">QuNetSim</a>, a quantum network Python simulation framework for investigating quantum network protocols. [
@@ -379,7 +379,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://vprusso.github.io/">Vincent Russo</a> to support
                                     <a href="https://vprusso.github.io/toqito/">toqito</a>, an open source Python toolkit for quantum information theory with extra functionality to study non-local games. [
@@ -391,7 +391,7 @@
                             <h4>2019 Grants</h4>
                         <br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="http://jankiewiczstudio.com/">Klementyna
                                         Jankiewicz</a> and
@@ -404,7 +404,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://www.linkedin.com/in/abdulko/">Abdul Karim
                                         Obeid</a> and the <a class="recipient-link" href="https://qhyp.info/">QHyp</a> project, developing research and software at the intersection of quantum contextuality and probabilistic programming. [
@@ -412,7 +412,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://github.com/vm6502q/qrack">Qrack</a> an open source, comprehensive, GPU-accelerated framework for simulating universal quantum processors. (Qrack has also passed the proof-of-concept stage for distributed simulation.) [
                                     <a href="https://qrack.readthedocs.io/en/latest/index.html">Docs</a>] [
@@ -420,7 +420,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://scholar.google.com/citations?user=WmghO7UAAAAJ">Alexandru
                                         Paler</a> and
@@ -430,7 +430,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="http://qworld.lu.lv/index.php/qcousins/">QCousins</a> to support their mission of welcoming a young and diverse group of programmers into quantum computing. The grant will fund more
                                     of their quantum programming <a href="http://qworld.lu.lv/index.php/workshop-bronze/">workshops</a> and <a href="http://qworld.lu.lv/index.php/qkitchen/">educational materials</a>. [
@@ -438,7 +438,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://www.scigym.net/">SciGym</a> to build open source library for reinforcement learning environments in science. Examples include
                                     <a href="https://www.scigym.net/env/gym-surfacecode">training a surface code
@@ -448,14 +448,14 @@
                         <h4>2018 Grants</h4>
                         <br>
                         <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="http://www.gate42.org/">Gate42</a> to build an open source library for quantum error mitigation and dynamical decoupling: both techniques for compiling programs to reduce the effect
                                     of noise in quantum processors.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To the <a href="https://github.com/QuantumAI-lib/NISQAI">NISQAI</a> project to build a library for machine learning with near-term quantum processors.
                                     <a href="https://github.com/QuantumAI-lib/NISQAI/blob/master/proposal/nisqai.pdf">[Proposal]</a>
@@ -465,7 +465,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://github.com/perak">Petar Korponaić</a> to support and extend the
                                     <a href="https://quantum-circuit.com/home">Quantum Programming Studio</a>, an open source in-browser IDE for multi-platform quantum programming. This project became the startup
@@ -475,7 +475,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://github.com/LSaldyt">Lucas Saldyt</a> to prototype a
                                     <a href="https://github.com/LSaldyt/unitary-proposal">
@@ -484,7 +484,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://www.cs.ru.nl/A.Kissinger/">Aleks
                                         Kissinger</a> and
@@ -498,7 +498,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://adamisntdead.com/">Adam Kelly</a> to extend his work on the open source
                                     <a href="https://qcgpu.github.io/">QCGPU</a> high performance quantum circuit simulator [
@@ -508,14 +508,14 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://github.com/ntwalibas" target="_blank">Ntwali Bashige</a> to develop the
                                     <a href="https://github.com/ntwalibas/unitary-proposal" target="_blank">Avalon</a> quantum programming language and quantum programming communities in India and D. R. Congo.
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="http://www.mustythoughts.com/about/" target="_blank">Michał Stęchły</a> to build a traveling salesman solver web application and <a class="recipient-link" href="https://github.com/mstechly/quantum_tsp_tutorials">tutorials</a>                                    for Forest based on the quantum approximate optimization algorithm.
                                     <a href="https://github.com/mstechly/quantum_tsp_tutorials">[github tutorials]</a>
@@ -526,7 +526,7 @@
                                 </p>
                             </li><br>
                             <li>
-                                <img class="grant-image" src="/images/dummy.png" alt="grant" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" />
                                 <p>
                                     To <a class="recipient-link" href="https://twitter.com/charl_bp" target="_blank">
                                         Carlos Bravo Prieto </a> to implement the Adiabatically Assisted Variational Quantum Eigensolvers in Forest, a hybrid classical-quantum algorithm for solving optimization problems.

--- a/grants.html
+++ b/grants.html
@@ -76,7 +76,7 @@
                         <h4 class="grant-year">2022 Grants</h4> 
                         <ul class="grant-list">
                            <li>
-                                <img class="grant-image" src="images/dummy.png" alt="grant" id="homl" />
+                                <img class="grant-image" src="images/dummy.png" alt="grant" id="inside-quantum" />
                                 <p>
                                     To <a class="recipient-link" href="https://steventhomson.co.uk/">Steven Thomson</a>, to create <a href="https://www.insidequantum.org">Inside Quantum</a>, a new quantum technology themed podcast focusing on the people behind the research, aimed at showcasing a diverse range of voices in order to promote inclusivity and inspire the next generation of quantum technologists. </p>
                             </li>

--- a/grants.html
+++ b/grants.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
-    <style type="text/css">
+    <style>
       #mc_embed_signup {
         background: #fff;
         clear: left;

--- a/ideas.html
+++ b/ideas.html
@@ -1,193 +1,246 @@
 <!DOCTYPE html>
 
 <html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
 
     <title>Unitary Fund</title>
     <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="style.css">
-    <link rel="stylesheet" type="text/css" href="hamburgers.min.css">
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
-    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-        #mc_embed_signup {
-            background: #fff;
-            clear: left;
-            font: 14px "Lucida Console", Monaco, monospace;
-            width: 100%;
-        }
-        
-        #mce-EMAIL {
-            padding: 11px;
-            margin: 10px;
-        }
+      #mc_embed_signup {
+        background: #fff;
+        clear: left;
+        font: 14px "Lucida Console", Monaco, monospace;
+        width: 100%;
+      }
+
+      #mce-EMAIL {
+        padding: 11px;
+        margin: 10px;
+      }
     </style>
 
     <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
+      window.dataLayer = window.dataLayer || []
 
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-        gtag('config', 'UA-19932157-4');
+      gtag("config", "UA-19932157-4")
     </script>
-</head>
+  </head>
 
-<body>
+  <body>
     <div class="layout">
-        <main id="content" class="content">
-            <section class="heavy">
-                <div class="container">
-                    <div class="col-3">
-                        <div class="hero">
-                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
-                            <p class="tagline"><b>Because evolution is
-                                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
-                                        target="_blank">unitary</a></b>.</p>
-                            <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
-                                <span class="hamburger-box">
-                                    <span class="hamburger-inner"></span>
-                                </span>
-                            </button>
-                        </div>
+      <main id="content" class="content">
+        <section class="heavy">
+          <div class="container">
+            <div class="col-3">
+              <div class="hero">
+                <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
+                <p class="tagline">
+                  <b
+                    >Because evolution is
+                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b
+                  >.
+                </p>
+                <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
+                  <span class="hamburger-box">
+                    <span class="hamburger-inner"></span>
+                  </span>
+                </button>
+              </div>
 
-                        <p class="subtitle leading-arrow"><a name="project-ideas">Project Inspiration</a></p>
-                        Looking for inspiration? This section contains links that might inspire new Unitary Fund projects.
+              <p class="subtitle leading-arrow">
+                <a name="project-ideas">Project Inspiration</a>
+              </p>
+              Looking for inspiration? This section contains links that might inspire new Unitary Fund projects.
 
-                        <p>
-                            Unitary Fund is supporting the development of
-                            <a href="http://www.qutip.org/">QuTiP</a>, the Quantum Toolbox in Python. Interested students can apply to propose a code project in QuTiP and be mentored by the core developers for a 3-month period, working remotely, similarly
-                            to the Google Summer of Code. A list of
-                            <a href="https://github.com/qutip/qutip/wiki/Google-Summer-of-Code-2020">
-                                project ideas</a> is available from the QuTiP wiki. Applications are open all-year-round.
-                        </p>
+              <p>
+                Unitary Fund is supporting the development of
+                <a href="http://www.qutip.org/">QuTiP</a>, the Quantum Toolbox in Python. Interested students can apply
+                to propose a code project in QuTiP and be mentored by the core developers for a 3-month period, working
+                remotely, similarly to the Google Summer of Code. A list of
+                <a href="https://github.com/qutip/qutip/wiki/Google-Summer-of-Code-2020"> project ideas</a>
+                is available from the QuTiP wiki. Applications are open all-year-round.
+              </p>
 
-                        <p>
-                            <a href="https://www.cgranade.com/">Cassandra Granade</a> - a UF Advisory Board member and senior developer on Microsoft's open source <a href="https://www.microsoft.com/en-ca/quantum/development-kit">Quantum Development
-                                Kit</a> - has some suggestions:
-                        </p>
-                            <ul style="list-style-type: none;">
-                                <li class="leading-block">Additional Q# simulators (e.g.: open systems or CHP simulators)
-                                </li>
-                                <li class="leading-block">New language interoperability; currently, can call into Q# from Python, C#, F#, VB.NET, or PowerShell</li>
-                                <li class="leading-block">Visualization and/or debugger tools (e.g.: improving the state visualizer sample)</li>
-                                <li class="leading-block">New libraries for quantum algorithms (e.g.: we’ve gotten requests for
-                                    <a href="https://arxiv.org/abs/0708.1879">QRAM</a> implementations and a <a href="https://arxiv.org/abs/quant-ph/9607014">Durr–Hoyer library)</a>
-                                </li>
-                            </ul>
+              <p>
+                <a href="https://www.cgranade.com/">Cassandra Granade</a> - a UF Advisory Board member and senior
+                developer on Microsoft's open source
+                <a href="https://www.microsoft.com/en-ca/quantum/development-kit">Quantum Development Kit</a>
+                - has some suggestions:
+              </p>
+              <ul style="list-style-type: none">
+                <li class="leading-block">Additional Q# simulators (e.g.: open systems or CHP simulators)</li>
+                <li class="leading-block">
+                  New language interoperability; currently, can call into Q# from Python, C#, F#, VB.NET, or PowerShell
+                </li>
+                <li class="leading-block">
+                  Visualization and/or debugger tools (e.g.: improving the state visualizer sample)
+                </li>
+                <li class="leading-block">
+                  New libraries for quantum algorithms (e.g.: we’ve gotten requests for
+                  <a href="https://arxiv.org/abs/0708.1879">QRAM</a>
+                  implementations and a
+                  <a href="https://arxiv.org/abs/quant-ph/9607014">Durr–Hoyer library)</a>
+                </li>
+              </ul>
 
+              <p>
+                <a href="http://travisscholten.com/">Travis Scholten</a> - an Advisory Board member from
+                <a href="https://www.ibm.com/quantum-computing/">IBM Quantum</a>
+                - suggests:
+              </p>
+              <ul style="list-style-type: none">
+                <li class="leading-block">
+                  Some of the larger issues in Qiskit Terra labelled as "<a
+                    href="https://github.com/Qiskit/qiskit-terra/labels/short%20project"
+                    >short projects</a
+                  >."
+                </li>
+                <li class="leading-block">
+                  Implementing the Solovay-Kitaev algorithm for approximating a given unitary by gates from a finite
+                  set, to arbitrary accuracy.
+                </li>
+                <li class="leading-block">
+                  Writing a simulator for parameterized quantum circuits, leveraging the Qiskit Parameter object.
+                </li>
+                <li class="leading-block">
+                  Building an encoder and decoder for quantum expander codes. (References
+                  <a href="https://arxiv.org/abs/1504.00822">here</a>,
+                  <a href="https://arxiv.org/abs/1808.03821">here</a>, and
+                  <a href="http://people.seas.harvard.edu/~madhusudan/courses/Spring2017/scribe/lect13.pdf">here</a>.)
+                </li>
+              </ul>
 
-                        <p>
-                            <a href="http://travisscholten.com/">Travis Scholten</a> - an Advisory Board member from
-                            <a href="https://www.ibm.com/quantum-computing/">IBM Quantum</a> - suggests:
-                        </p>
-                            <ul style="list-style-type: none;">
-                                <li class="leading-block">Some of the larger issues in Qiskit Terra labelled as "<a href="https://github.com/Qiskit/qiskit-terra/labels/short%20project">short
-                                    projects</a>."</li>
-                                <li class="leading-block">Implementing the Solovay-Kitaev algorithm for approximating a given unitary by gates from a finite set, to arbitrary accuracy.</li>
-                                <li class="leading-block">Writing a simulator for parameterized quantum circuits, leveraging the Qiskit Parameter object.</li>
-                                <li class="leading-block">Building an encoder and decoder for quantum expander codes. (References <a href="https://arxiv.org/abs/1504.00822">here</a>, <a href="https://arxiv.org/abs/1808.03821">here</a>, and <a href="http://people.seas.harvard.edu/~madhusudan/courses/Spring2017/scribe/lect13.pdf">here</a>.)
-                                </li>
-                            </ul>
+              <p>
+                <a href="www.mustythoughts.com">Michał Stęchły </a> - an Advisory Board member from
+                <a href="https://www.zapatacomputing.com/">Zapata Computing</a>
+                - shares his ideas:
+              </p>
+              <ul style="list-style-type: none">
+                <li class="leading-block">
+                  Visualization tools for high-dimension optimization landscapes could help get better insight into
+                  algorithms like QAOA or VQE.
+                  <a href="https://github.com/zapatacomputing/orqviz">Orqviz</a>
+                  is our attempt to tackle this issue, but contributions / other attempts would be welcome.
+                </li>
+                <li class="leading-block">
+                  At QOSF we have done
+                  <a href="https://qosf.org/evaluation/">evaluation of open source projects</a>
+                  in quantum in 2018. Help with updating and automating the process would be appreciated.
+                </li>
+                <li class="leading-block">
+                  Many QC-related projects are scientifically solid, but lack on the software engineering side – murky
+                  architecture, lack of tests, versioning, CICD, etc. I believe improving the quality of the software
+                  could greatly benefit the community.
+                </li>
+              </ul>
 
-                        <p>
-                            <a href="www.mustythoughts.com">Michał Stęchły </a> - an Advisory Board member from
-                            <a href="https://www.zapatacomputing.com/">Zapata Computing</a> - shares his ideas:
-                        </p>
-                            <ul style="list-style-type: none;">
-                                <li class="leading-block">Visualization tools for high-dimension optimization landscapes could help get better insight into algorithms like QAOA or VQE. <a href="https://github.com/zapatacomputing/orqviz">Orqviz</a> is our attempt to tackle this issue, but contributions / other attempts would be welcome.</li>
-                                <li class="leading-block">At QOSF we have done <a href="https://qosf.org/evaluation/">evaluation of open source projects</a> in quantum in 2018. Help with updating and automating the process would be appreciated.
-                                </li>
-                                <li class="leading-block">Many QC-related projects are scientifically solid, but lack on the software engineering side – murky architecture, lack of tests, versioning, CICD, etc. I believe improving the quality of the software could greatly benefit the community.
-                                </li>
-                            </ul>
-
-                        <footer class="footer leading-arrow light-arrow">
-                            This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
-                                of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request!
-                            <br>
-                            <br>
-                            <table>
-                                <tr>
-                                    <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                                class="fa fa-twitter"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                                class="fa fa-twitch"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                                class="fa fa-youtube"></i></a></th>
-                                    <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                                class="fab fa-discord"></i></a></th>
-                                </tr>
-                            </table> &copy;2020 Unitary Fund
-                        </footer>
-                    </div>
-                    <div class="col-1" id="menu-container">
-                        <table style="width:auto; margin-right:0px; margin-left: auto;">
-                            <tr>
-                                <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                            class="fa fa-twitter"></i></a></th>
-                                <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                            class="fa fa-twitch"></i></a></th>
-                                <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                            class="fa fa-youtube"></i></a></th>
-                                <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                            class="fab fa-discord"></i></a></th>
-                            </tr>
-                        </table>
-                        <p class="light" id="menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html" class="active">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                    <div id="mobile-menu-container">
-                        <p class="light" id="mobile-menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html" class="active">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                </div>
-            </section>
-        </main>
+              <footer class="footer leading-arrow light-arrow">
+                This website is hosted on
+                <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community
+                follows this
+                <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a
+                >. <br />
+                <br />
+                If you have suggestions for changes then please open up a pull request!
+                <br />
+                <br />
+                <table>
+                  <tr>
+                    <th style="text-align: right">
+                      <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"
+                        ><i class="fa fa-youtube"></i
+                      ></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                    </th>
+                  </tr>
+                </table>
+                &copy;2020 Unitary Fund
+              </footer>
+            </div>
+            <div class="col-1" id="menu-container">
+              <table style="width: auto; margin-right: 0px; margin-left: auto">
+                <tr>
+                  <th style="text-align: right">
+                    <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                  </th>
+                </tr>
+              </table>
+              <p class="light" id="menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html" class="active">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+            <div id="mobile-menu-container">
+              <p class="light" id="mobile-menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html" class="active">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
     <script>
-        var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
-        mobileMenuContainer = document.querySelector("#mobile-menu-container");
-        mobileMenuIcon.addEventListener("click", function() {
-            mobileMenuIcon.classList.toggle("is-active");
-            mobileMenuContainer.classList.toggle("active");
-        });
+      var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
+      mobileMenuContainer = document.querySelector("#mobile-menu-container")
+      mobileMenuIcon.addEventListener("click", function () {
+        mobileMenuIcon.classList.toggle("is-active")
+        mobileMenuContainer.classList.toggle("active")
+      })
     </script>
-</body>
-
+  </body>
 </html>

--- a/ideas.html
+++ b/ideas.html
@@ -81,9 +81,9 @@
                         </p>
                             <ul style="list-style-type: none;">
                                 <li class="leading-block">Additional Q# simulators (e.g.: open systems or CHP simulators)
-                                </li><br>
-                                <li class="leading-block">New language interoperability; currently, can call into Q# from Python, C#, F#, VB.NET, or PowerShell</li><br>
-                                <li class="leading-block">Visualization and/or debugger tools (e.g.: improving the state visualizer sample)</li><br>
+                                </li>
+                                <li class="leading-block">New language interoperability; currently, can call into Q# from Python, C#, F#, VB.NET, or PowerShell</li>
+                                <li class="leading-block">Visualization and/or debugger tools (e.g.: improving the state visualizer sample)</li>
                                 <li class="leading-block">New libraries for quantum algorithms (e.g.: we’ve gotten requests for
                                     <a href="https://arxiv.org/abs/0708.1879">QRAM</a> implementations and a <a href="https://arxiv.org/abs/quant-ph/9607014">Durr–Hoyer library)</a>
                                 </li>
@@ -96,9 +96,9 @@
                         </p>
                             <ul style="list-style-type: none;">
                                 <li class="leading-block">Some of the larger issues in Qiskit Terra labelled as "<a href="https://github.com/Qiskit/qiskit-terra/labels/short%20project">short
-                                    projects</a>."</li><br>
-                                <li class="leading-block">Implementing the Solovay-Kitaev algorithm for approximating a given unitary by gates from a finite set, to arbitrary accuracy.</li><br>
-                                <li class="leading-block">Writing a simulator for parameterized quantum circuits, leveraging the Qiskit Parameter object.</li><br>
+                                    projects</a>."</li>
+                                <li class="leading-block">Implementing the Solovay-Kitaev algorithm for approximating a given unitary by gates from a finite set, to arbitrary accuracy.</li>
+                                <li class="leading-block">Writing a simulator for parameterized quantum circuits, leveraging the Qiskit Parameter object.</li>
                                 <li class="leading-block">Building an encoder and decoder for quantum expander codes. (References <a href="https://arxiv.org/abs/1504.00822">here</a>, <a href="https://arxiv.org/abs/1808.03821">here</a>, and <a href="http://people.seas.harvard.edu/~madhusudan/courses/Spring2017/scribe/lect13.pdf">here</a>.)
                                 </li>
                             </ul>
@@ -108,11 +108,11 @@
                             <a href="https://www.zapatacomputing.com/">Zapata Computing</a> - shares his ideas:
                         </p>
                             <ul style="list-style-type: none;">
-                                <li class="leading-block">Visualization tools for high-dimension optimization landscapes could help get better insight into algorithms like QAOA or VQE. <a href="https://github.com/zapatacomputing/orqviz">Orqviz</a> is our attempt to tackle this issue, but contributions / other attempts would be welcome.</li><br>
+                                <li class="leading-block">Visualization tools for high-dimension optimization landscapes could help get better insight into algorithms like QAOA or VQE. <a href="https://github.com/zapatacomputing/orqviz">Orqviz</a> is our attempt to tackle this issue, but contributions / other attempts would be welcome.</li>
                                 <li class="leading-block">At QOSF we have done <a href="https://qosf.org/evaluation/">evaluation of open source projects</a> in quantum in 2018. Help with updating and automating the process would be appreciated.
-                                </li><br>
+                                </li>
                                 <li class="leading-block">Many QC-related projects are scientifically solid, but lack on the software engineering side – murky architecture, lack of tests, versioning, CICD, etc. I believe improving the quality of the software could greatly benefit the community.
-                                </li><br>
+                                </li>
                             </ul>
 
                         <footer class="footer leading-arrow light-arrow">

--- a/ideas.html
+++ b/ideas.html
@@ -53,7 +53,7 @@
                 <div class="container">
                     <div class="col-3">
                         <div class="hero">
-                            <a href="/"><img src="/logos/logov3.svg" alt="Unitary Fund" /></a>
+                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
                             <p class="tagline"><b>Because evolution is
                                     <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
                                         target="_blank">unitary</a></b>.</p>

--- a/ideas.html
+++ b/ideas.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 
 <html>
-<script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -32,6 +31,7 @@
         }
     </style>
 
+    <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>

--- a/ideas.html
+++ b/ideas.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/ideas.html
+++ b/ideas.html
@@ -66,9 +66,7 @@
                 </button>
               </div>
 
-              <p class="subtitle leading-arrow">
-                <a name="project-ideas">Project Inspiration</a>
-              </p>
+              <p class="subtitle leading-arrow">Project Inspiration</p>
               Looking for inspiration? This section contains links that might inspire new Unitary Fund projects.
 
               <p>

--- a/ideas.html
+++ b/ideas.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
-    <style type="text/css">
+    <style>
       #mc_embed_signup {
         background: #fff;
         clear: left;

--- a/ideas.html
+++ b/ideas.html
@@ -78,6 +78,7 @@
                         <p>
                             <a href="https://www.cgranade.com/">Cassandra Granade</a> - a UF Advisory Board member and senior developer on Microsoft's open source <a href="https://www.microsoft.com/en-ca/quantum/development-kit">Quantum Development
                                 Kit</a> - has some suggestions:
+                        </p>
                             <ul style="list-style-type: none;">
                                 <li class="leading-block">Additional Q# simulators (e.g.: open systems or CHP simulators)
                                 </li><br>
@@ -87,12 +88,12 @@
                                     <a href="https://arxiv.org/abs/0708.1879">QRAM</a> implementations and a <a href="https://arxiv.org/abs/quant-ph/9607014">Durr–Hoyer library)</a>
                                 </li>
                             </ul>
-                        </p>
 
 
                         <p>
                             <a href="http://travisscholten.com/">Travis Scholten</a> - an Advisory Board member from
                             <a href="https://www.ibm.com/quantum-computing/">IBM Quantum</a> - suggests:
+                        </p>
                             <ul style="list-style-type: none;">
                                 <li class="leading-block">Some of the larger issues in Qiskit Terra labelled as "<a href="https://github.com/Qiskit/qiskit-terra/labels/short%20project">short
                                     projects</a>."</li><br>
@@ -101,11 +102,11 @@
                                 <li class="leading-block">Building an encoder and decoder for quantum expander codes. (References <a href="https://arxiv.org/abs/1504.00822">here</a>, <a href="https://arxiv.org/abs/1808.03821">here</a>, and <a href="http://people.seas.harvard.edu/~madhusudan/courses/Spring2017/scribe/lect13.pdf">here</a>.)
                                 </li>
                             </ul>
-                        </p>
 
                         <p>
                             <a href="www.mustythoughts.com">Michał Stęchły </a> - an Advisory Board member from
                             <a href="https://www.zapatacomputing.com/">Zapata Computing</a> - shares his ideas:
+                        </p>
                             <ul style="list-style-type: none;">
                                 <li class="leading-block">Visualization tools for high-dimension optimization landscapes could help get better insight into algorithms like QAOA or VQE. <a href="https://github.com/zapatacomputing/orqviz">Orqviz</a> is our attempt to tackle this issue, but contributions / other attempts would be welcome.</li><br>
                                 <li class="leading-block">At QOSF we have done <a href="https://qosf.org/evaluation/">evaluation of open source projects</a> in quantum in 2018. Help with updating and automating the process would be appreciated.
@@ -113,7 +114,6 @@
                                 <li class="leading-block">Many QC-related projects are scientifically solid, but lack on the software engineering side – murky architecture, lack of tests, versioning, CICD, etc. I believe improving the quality of the software could greatly benefit the community.
                                 </li><br>
                             </ul>
-                        </p>
 
                         <footer class="footer leading-arrow light-arrow">
                             This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code

--- a/index.html
+++ b/index.html
@@ -69,10 +69,8 @@
                             <li class="leading-block"><b>We run a microgrant program</b> to fund <a href="grants.html">explorers</a> across the world to work on quantum technologies. Do you have an idea for a project? <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank"
                                     style="background-color:var(--color-yellow);">Apply for a
                                     microgrant</a>. See our <a href="faq.html">FAQ</a> and <a href="grants.html">previous grants</a>. </li>
-                            <br>
                             <li class="leading-block"><b>We do our own research</b> to help the ecosystem as a whole. For example, we are developing <a href="mitiq.html" target="_blank" style="background-color:var(--color-yellow);">mitiq</a>, an open source compiler for error-mitigated
                                 quantum programming. </li>
-                            <br>
                             <li class="leading-block"><b>We host an open source quantum tech community</b> that runs <a href="https://unitaryfund.github.io/unitaryhack/">hackathons</a> and events on our <a href="http://discord.unitary.fund">Discord</a>.
                                 <a style="background-color:var(--color-yellow);" href="talks.html"> 📅 Calendar</a></li>
                         </ul>
@@ -114,12 +112,10 @@
                             <p class="subtitle leading-arrow">Supporters</p>
                             Learn more about our <a href="https://unitary.fund/posts/2021-corporate-members.html" target="_blank">corporate membership program</a>.
                             <ul style="list-style-type: none;">
-                                <li class="leading-block"><b>Core Members:</b> <a href="https://www.ibm.com/us-en/?ar=1">IBM</a> and <a href="https://www.accenture.com/us-en">Accenture</a> </li>
-                                <br>
+                                <li class="leading-block"><b>Core Members:</b> <a href="https://www.ibm.com/us-en/?ar=1">IBM</a> and <a href="https://www.accenture.com/us-en>">Accenture</a> </li>
                                 <li class="leading-block"><b>Supporting Members:</b> <a href="https://xanadu.ai/">Xanadu</a>, <a href="https://ionq.com/">IonQ</a>, <a href="https://www.bcg.com/en-us/">Boston Consulting Group</a>, <a href="https://pasqal.io/">Pasqal</a>,
                                     <a href="https://www.meetiqm.com/">IQM</a>, <a href="https://hidorahacks.medium.com/">DoraHacks</a>, <a href="https://agnostiq.ai/">Agnostiq</a>
                                 </li>
-                                <br>
                                 <li class="leading-block"><b>Other Supporters:</b> <a href="https://x.company/">Alphabet X
                                     (formerly Google X)</a>, <a href="https://www.microsoft.com/en-us/">Microsoft</a>, <a href="https://cambridgequantum.com/">Cambridge Quantum Computing</a>, <a href="https://www.rigetti.com/">Rigetti</a>, <a href="https://www.zapatacomputing.com/">Zapata Computing</a>,
                                     <a href="https://qcware.com/">QCWare</a>, <a href="http://quantumcomputing.com/">quantumcomputing.com</a>, <a href="https://strangeworks.com/">Strangeworks</a>, <a href="https://www.plos.org/" target="_blank">PLOS</a>,

--- a/index.html
+++ b/index.html
@@ -115,10 +115,7 @@
               </p>
               <p>
                 Read our
-                <a
-                  href="assets/Unitary_Fund_2021_Report.pdf"
-                  style="background-color: var(--color-yellow)"
-                  name="2021-report"
+                <a href="assets/Unitary_Fund_2021_Report.pdf" style="background-color: var(--color-yellow)"
                   >2021 Annual Report</a
                 >
                 and see what we got up to last year.
@@ -160,7 +157,7 @@
                 </form>
               </div>
               <!--End mc_embed_signup-->
-              <a href="http://discord.unitary.fund" name="discord">
+              <a href="http://discord.unitary.fund">
                 <figure>
                   <img
                     style="max-width: 100%; height: auto; margin: auto; display: block"
@@ -235,9 +232,7 @@
                 backgrounds.”
               </p>
               <p style="font-size: 14px">— Travis L. Scholten, IBM Quantum</p>
-              <p class="subtitle">
-                <a name="advisors" class="leading-arrow">Advisors</a>
-              </p>
+              <p class="subtitle leading-arrow">Advisors</p>
               <p>
                 Thanks to the
                 <a href="posts/advisory_board.html" target="_blank">Advisory Board</a>
@@ -246,9 +241,7 @@
                 Mark Fingerhuth, Michał Stęchły, Nathan Killoran, Ntwali Bashige, Peter Karalekas, Roger Luo, Shahnawaz
                 Ahmed, Hannah Sim, Tomas Babej, Travis L. Scholten
               </p>
-              <p class="subtitle">
-                <a name="team" class="leading-arrow">Unitary Fund Team</a>
-              </p>
+              <p class="subtitle leading-arrow">Unitary Fund Team</p>
               <a href="https://www.sckaiser.com/">Sarah Kaiser</a>,
               <a href="https://www.ryanlarose.com/">Ryan LaRose</a>,
               <a href="https://sites.google.com/site/andreamari84/">Andrea Mari</a>,

--- a/index.html
+++ b/index.html
@@ -131,36 +131,34 @@
                   >started as a small microgrant program for open source quantum software projects</a
                 >.
               </p>
-              <center>
-                <!-- Begin MailChimp Signup Form -->
-                <div id="mc_embed_signup">
-                  <form
-                    action="https://fund.us18.list-manage.com/subscribe/post?u=104796c75ced8350ebd01eebd&amp;id=a2c9e5ac2a"
-                    method="post"
-                    id="mc-embedded-subscribe-form"
-                    name="mc-embedded-subscribe-form"
-                    class="validate"
-                    target="_blank"
-                    novalidate>
-                    <div id="mc_embed_signup_scroll">
-                      <label for="mce-EMAIL">Stay updated on our work:</label><br /><br />
-                      <input type="email" value="my@email.com" name="EMAIL" class="email" id="mce-EMAIL" required />
-                      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-                      <div style="position: absolute; left: -5000px" aria-hidden="true">
-                        <input type="text" name="b_104796c75ced8350ebd01eebd_a2c9e5ac2a" tabindex="-1" value="" />
-                      </div>
-                      <!--<div class="clear">-->
-                      <input
-                        type="submit"
-                        value="Subscribe"
-                        name="subscribe"
-                        id="mc-embedded-subscribe"
-                        class="button heavy square-button" />
-                      <!--</div>-->
+              <!-- Begin MailChimp Signup Form -->
+              <div id="mc_embed_signup" style="text-align: center">
+                <form
+                  action="https://fund.us18.list-manage.com/subscribe/post?u=104796c75ced8350ebd01eebd&amp;id=a2c9e5ac2a"
+                  method="post"
+                  id="mc-embedded-subscribe-form"
+                  name="mc-embedded-subscribe-form"
+                  class="validate"
+                  target="_blank"
+                  novalidate>
+                  <div id="mc_embed_signup_scroll">
+                    <label for="mce-EMAIL">Stay updated on our work:</label><br /><br />
+                    <input type="email" value="my@email.com" name="EMAIL" class="email" id="mce-EMAIL" required />
+                    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                    <div style="position: absolute; left: -5000px" aria-hidden="true">
+                      <input type="text" name="b_104796c75ced8350ebd01eebd_a2c9e5ac2a" tabindex="-1" value="" />
                     </div>
-                  </form>
-                </div>
-              </center>
+                    <!--<div class="clear">-->
+                    <input
+                      type="submit"
+                      value="Subscribe"
+                      name="subscribe"
+                      id="mc-embedded-subscribe"
+                      class="button heavy square-button" />
+                    <!--</div>-->
+                  </div>
+                </form>
+              </div>
               <!--End mc_embed_signup-->
               <a href="http://discord.unitary.fund" name="discord">
                 <figure>
@@ -217,15 +215,13 @@
                   <a href="https://twitter.com/wjzeng" target="_blank">Will Zeng</a>
                 </li>
               </ul>
-              <center>
-                <p>
-                  <a
-                    href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NYN7D2ADDYQ78&source=url"
-                    style="background-color: var(--color-yellow)">
-                    Donate your support!
-                  </a>
-                </p>
-              </center>
+              <p style="text-align: center">
+                <a
+                  href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NYN7D2ADDYQ78&source=url"
+                  style="background-color: var(--color-yellow)">
+                  Donate your support!
+                </a>
+              </p>
               <p style="font-size: 14px; font-style: italic">
                 “I imagine that years from now, some of the biggest contributors in quantum computing will have come
                 through the Unitary Fund program. The grants provide avenues for creative, motivated folks to

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
                         </ul>
                         <p>We give <b>$4k</b> cash grants to quantum tech <a href="grants.html">projects</a>. Projects could be open source quantum software, educational materials and workshops, a new quantum sensor prototype, or much more.</p>
                         <p>Our program is designed to be as simple as possible. No organizational affiliation required. Just a short form and a two minute video.</p>
-                        <p>For more information or to check on your application email <a href="mailto:info@unitary.fund">info@unitary.fund</a>.
+                        For more information or to check on your application email <a href="mailto:info@unitary.fund">info@unitary.fund</a>.
                             <p>Through our partners, we offer free credits to run on Rigetti's <a href="https://docs.rigetti.com/en/">Quantum Cloud Services</a> and priority-tier access to <a href="https://www.ibm.com/quantum-computing/technology/systems">IBMQ's publicly
                                 available devices</a>. </p>
                             <p>Read our <a href="assets/Unitary_Fund_2021_Report.pdf" style="background-color:var(--color-yellow)" name="2021-report">2021 Annual Report</a> and see what we got up to last year. </p>
@@ -136,7 +136,6 @@
                                     <a href="https://www.linkedin.com/in/christophe-jurczak" target="_blank">Christophe Jurczak</a>,
                                     <a href="https://twitter.com/wjzeng" target="_blank">Will Zeng</a></li>
                             </ul>
-                        </p>
                         <center>
                             <p>
                                 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NYN7D2ADDYQ78&source=url" style="background-color:var(--color-yellow)"> Donate your support! </a>
@@ -151,12 +150,10 @@
                         <p> Thanks to the <a href="posts/advisory_board.html" target="_blank">Advisory Board</a> for helping source and review applications! <br><br> Alex McCaskey, Amira Abbas, Amy Brown, Cassandra Granade, Christa Zoufal, Josh Izaac, Stephen DiAdamo, Mark Fingerhuth, Michał
                             Stęchły, Nathan Killoran, Ntwali Bashige, Peter Karalekas, Roger Luo, Shahnawaz Ahmed, Hannah Sim, Tomas Babej, Travis L. Scholten </p>
                         <p class="subtitle"><a name="team" class="leading-arrow">Unitary Fund Team</a></p>
-                        <a>
                             <a href="https://www.sckaiser.com/">Sarah Kaiser</a>, <a href="https://www.ryanlarose.com/">Ryan LaRose</a>, <a href="https://sites.google.com/site/andreamari84/">Andrea Mari</a>, <a href="https://nathanshammah.com/">Nathan Shammah</a>,
                             <a href="https://github.com/wrathfulspatula">Daniel Strano</a>, <a href="https://github.com/vprusso">Vincent Russo</a>, 
                             <a href="https://github.com/Misty-W">Misty Wahl</a>, <a href="https://natestemen.xyz">Nate Stemen</a>, Alowina Yap, <a href="https://uxfol.io/francespoblete">Frances Poblete</a>, & <a href="http://willzeng.com/"
                                 target="_blank">Will Zeng</a>.
-                            </p>
                             <footer class="footer leading-arrow light-arrow"> This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
                                 of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request! <br>
                                 <br>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" type="text/css" href="style.css" />
     <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
-    <style type="text/css">
+    <style>
       #mc_embed_signup {
         background: #fff;
         clear: left;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html>
-<script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -27,6 +26,7 @@
             margin: 10px;
         }
     </style>
+    <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>

--- a/index.html
+++ b/index.html
@@ -137,7 +137,8 @@
                   name="mc-embedded-subscribe-form"
                   class="validate"
                   target="_blank"
-                  novalidate>
+                  novalidate
+                >
                   <div id="mc_embed_signup_scroll">
                     <label for="mce-EMAIL">Stay updated on our work:</label><br /><br />
                     <input type="email" value="my@email.com" name="EMAIL" class="email" id="mce-EMAIL" required />
@@ -151,7 +152,8 @@
                       value="Subscribe"
                       name="subscribe"
                       id="mc-embedded-subscribe"
-                      class="button heavy square-button" />
+                      class="button heavy square-button"
+                    />
                     <!--</div>-->
                   </div>
                 </form>
@@ -162,7 +164,8 @@
                   <img
                     style="max-width: 100%; height: auto; margin: auto; display: block"
                     src="./logos/discord-banner.png"
-                    alt="unitary-fund-discord" />
+                    alt="unitary-fund-discord"
+                  />
                 </figure>
               </a>
               <p class="subtitle leading-arrow">Supporters</p>
@@ -215,7 +218,8 @@
               <p style="text-align: center">
                 <a
                   href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NYN7D2ADDYQ78&source=url"
-                  style="background-color: var(--color-yellow)">
+                  style="background-color: var(--color-yellow)"
+                >
                   Donate your support!
                 </a>
               </p>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
                 <div class="container">
                     <div class="col-3">
                         <div class="hero">
-                            <a href="/"><img src="/logos/logov3.svg" alt="Unitary Fund" /></a>
+                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
                             <p class="tagline"><b>Because evolution is <a
                                         href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
                                         target="_blank">unitary</a></b>.</p>

--- a/index.html
+++ b/index.html
@@ -1,230 +1,354 @@
 <!DOCTYPE html>
 <html>
-
-<head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="/favicon/site.webmanifest">
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
     <title>Unitary Fund</title>
     <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="style.css">
-    <link rel="stylesheet" type="text/css" href="hamburgers.min.css">
-    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
+    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-        #mc_embed_signup {
-            background: #fff;
-            clear: left;
-            font: 14px "Lucida Console", Monaco, monospace;
-            width: 100%;
-        }
-        
-        #mce-EMAIL {
-            padding: 11px;
-            margin: 10px;
-        }
+      #mc_embed_signup {
+        background: #fff;
+        clear: left;
+        font: 14px "Lucida Console", Monaco, monospace;
+        width: 100%;
+      }
+
+      #mce-EMAIL {
+        padding: 11px;
+        margin: 10px;
+      }
     </style>
     <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
+      window.dataLayer = window.dataLayer || []
 
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-        gtag('config', 'UA-19932157-4');
+      gtag("config", "UA-19932157-4")
     </script>
-</head>
+  </head>
 
-<body>
+  <body>
     <div class="layout">
-        <main id="content" class="content">
-            <section class="heavy">
-                <div class="container">
-                    <div class="col-3">
-                        <div class="hero">
-                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
-                            <p class="tagline"><b>Because evolution is <a
-                                        href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
-                                        target="_blank">unitary</a></b>.</p>
-                            <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
-                                <span class="hamburger-box">
-                                    <span class="hamburger-inner"></span>
-                                </span>
-                            </button>
-                        </div>
-                        <p class="leading-arrow"> <b>Unitary Fund</b> is a 501(c)(3) non-profit helping create a quantum technology ecosystem that benefits the most people. </p>
-                        <p>
-                            <b style="background-color:var(--color-yellow);">We just
-                                posted our <a href="https://unitary.fund/posts/2021.html">2021 annual report</a></b>!
-                        </p>
+      <main id="content" class="content">
+        <section class="heavy">
+          <div class="container">
+            <div class="col-3">
+              <div class="hero">
+                <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
+                <p class="tagline">
+                  <b
+                    >Because evolution is
+                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b
+                  >.
+                </p>
+                <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
+                  <span class="hamburger-box">
+                    <span class="hamburger-inner"></span>
+                  </span>
+                </button>
+              </div>
+              <p class="leading-arrow">
+                <b>Unitary Fund</b> is a 501(c)(3) non-profit helping create a quantum technology ecosystem that
+                benefits the most people.
+              </p>
+              <p>
+                <b style="background-color: var(--color-yellow)"
+                  >We just posted our <a href="https://unitary.fund/posts/2021.html">2021 annual report</a></b
+                >!
+              </p>
 
-                        <p> We do three main things: </p>
-                        <ul style="list-style-type: none;">
-                            <li class="leading-block"><b>We run a microgrant program</b> to fund <a href="grants.html">explorers</a> across the world to work on quantum technologies. Do you have an idea for a project? <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank"
-                                    style="background-color:var(--color-yellow);">Apply for a
-                                    microgrant</a>. See our <a href="faq.html">FAQ</a> and <a href="grants.html">previous grants</a>. </li>
-                            <li class="leading-block"><b>We do our own research</b> to help the ecosystem as a whole. For example, we are developing <a href="mitiq.html" target="_blank" style="background-color:var(--color-yellow);">mitiq</a>, an open source compiler for error-mitigated
-                                quantum programming. </li>
-                            <li class="leading-block"><b>We host an open source quantum tech community</b> that runs <a href="https://unitaryfund.github.io/unitaryhack/">hackathons</a> and events on our <a href="http://discord.unitary.fund">Discord</a>.
-                                <a style="background-color:var(--color-yellow);" href="talks.html"> 📅 Calendar</a></li>
-                        </ul>
-                        <p>We give <b>$4k</b> cash grants to quantum tech <a href="grants.html">projects</a>. Projects could be open source quantum software, educational materials and workshops, a new quantum sensor prototype, or much more.</p>
-                        <p>Our program is designed to be as simple as possible. No organizational affiliation required. Just a short form and a two minute video.</p>
-                        For more information or to check on your application email <a href="mailto:info@unitary.fund">info@unitary.fund</a>.
-                            <p>Through our partners, we offer free credits to run on Rigetti's <a href="https://docs.rigetti.com/en/">Quantum Cloud Services</a> and priority-tier access to <a href="https://www.ibm.com/quantum-computing/technology/systems">IBMQ's publicly
-                                available devices</a>. </p>
-                            <p>Read our <a href="assets/Unitary_Fund_2021_Report.pdf" style="background-color:var(--color-yellow)" name="2021-report">2021 Annual Report</a> and see what we got up to last year. </p>
-                            <p> Unitary Fund is built to help the quantum industry, in a small way, to cross the chasm. We
-                                <a href="https://medium.com/@wjzeng/the-unitary-fund-get-2-000-for-your-open-source-quantum-computing-project-d4b4c76ba177" target="_blank">started as a small microgrant program for open source quantum software
-                                projects</a>. </p>
-                            <center>
-                                <!-- Begin MailChimp Signup Form -->
-                                <div id="mc_embed_signup">
-                                    <form action="https://fund.us18.list-manage.com/subscribe/post?u=104796c75ced8350ebd01eebd&amp;id=a2c9e5ac2a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-                                        <div id="mc_embed_signup_scroll">
-                                            <label for="mce-EMAIL">Stay updated on our work:</label><br><br>
-                                            <input type="email" value="my@email.com" name="EMAIL" class="email" id="mce-EMAIL" required>
-                                            <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-                                            <div style="position: absolute; left: -5000px;" aria-hidden="true">
-                                                <input type="text" name="b_104796c75ced8350ebd01eebd_a2c9e5ac2a" tabindex="-1" value="">
-                                            </div>
-                                            <!--<div class="clear">-->
-                                            <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button heavy square-button">
-                                            <!--</div>-->
-                                        </div>
-                                    </form>
-                                </div>
-                            </center>
-                            <!--End mc_embed_signup-->
-                            <a href="http://discord.unitary.fund" name="discord">
-                                <figure>
-                                    <img style="max-width: 100%;
-                                        height: auto; margin: auto;
-                                display: block;" src="./logos/discord-banner.png" alt="unitary-fund-discord" />
-                                </figure>
-                            </a>
-                            <p class="subtitle leading-arrow">Supporters</p>
-                            Learn more about our <a href="https://unitary.fund/posts/2021-corporate-members.html" target="_blank">corporate membership program</a>.
-                            <ul style="list-style-type: none;">
-                                <li class="leading-block"><b>Core Members:</b> <a href="https://www.ibm.com/us-en/?ar=1">IBM</a> and <a href="https://www.accenture.com/us-en>">Accenture</a> </li>
-                                <li class="leading-block"><b>Supporting Members:</b> <a href="https://xanadu.ai/">Xanadu</a>, <a href="https://ionq.com/">IonQ</a>, <a href="https://www.bcg.com/en-us/">Boston Consulting Group</a>, <a href="https://pasqal.io/">Pasqal</a>,
-                                    <a href="https://www.meetiqm.com/">IQM</a>, <a href="https://hidorahacks.medium.com/">DoraHacks</a>, <a href="https://agnostiq.ai/">Agnostiq</a>
-                                </li>
-                                <li class="leading-block"><b>Other Supporters:</b> <a href="https://x.company/">Alphabet X
-                                    (formerly Google X)</a>, <a href="https://www.microsoft.com/en-us/">Microsoft</a>, <a href="https://cambridgequantum.com/">Cambridge Quantum Computing</a>, <a href="https://www.rigetti.com/">Rigetti</a>, <a href="https://www.zapatacomputing.com/">Zapata Computing</a>,
-                                    <a href="https://qcware.com/">QCWare</a>, <a href="http://quantumcomputing.com/">quantumcomputing.com</a>, <a href="https://strangeworks.com/">Strangeworks</a>, <a href="https://www.plos.org/" target="_blank">PLOS</a>,
-                                    <a href="https://www.meetup.com/New-York-Quantum-Computing-Meetup/" target="_blank">Steve
-                                        Willis & NYC Quantum Meetup</a>, <a href="https://www.eeroq.com/" target="_blank">EeroQ</a>, <a href="https://twitter.com/johnhering" target="_blank">John
-                                        Hering</a>, Jeff Cordova, <a href="https://twitter.com/nalidoust" target="_blank">Nima
-                                        Alidoust</a>, <a href="https://www.ornl.gov/staff-profile/travis-s-humble" target="_blank">Travis Humble</a>, George Umbrarescu,
-                                    <a href="https://www.zapatacomputing.com/team/greg-ramsay/" target="_blank">Greg Ramsay</a>,
-                                    <a href="https://www.zapatacomputing.com/team/peter-johnson/" target="_blank">Peter Johnson</a>,
-                                    <a href="https://twitter.com/quantumverd" target="_blank">Guillaume Verdon</a>,
-                                    <a href="https://www.linkedin.com/in/rishisr33dhar/" target="_blank">Rishi Sreedhar</a>,
-                                    <a href="https://twitter.com/Travis_Sch" target="_blank">Travis L. Scholten</a>,
-                                    <a href="https://www.linkedin.com/in/amirebrahimi/" target="_blank">Amir Ebrahimi</a>,
-                                    <a href="https://www.linkedin.com/in/christophe-jurczak" target="_blank">Christophe Jurczak</a>,
-                                    <a href="https://twitter.com/wjzeng" target="_blank">Will Zeng</a></li>
-                            </ul>
-                        <center>
-                            <p>
-                                <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NYN7D2ADDYQ78&source=url" style="background-color:var(--color-yellow)"> Donate your support! </a>
-                            </p>
-                        </center>
-                        <p style="font-size:14px; font-style:italic">“I imagine that years from now, some of the biggest contributors in quantum computing will have come through the Unitary Fund program. The grants provide avenues for creative, motivated folks to meaningfully contribute to this
-                            new industry. Awardees are using the program to launch their careers in quantum computing, landing jobs at Zapata and elsewhere.”</p>
-                        <p style="font-size:14px;">—Peter Johnson, Co-Founder, Zapata Computing</p>
-                        <p style="font-size:14px; font-style:italic">“Our support of the Unitary Fund enables continued growth of the quantum computing ecosystem. It is an opportunity to connect with and help quantum developers from a diverse range of skill sets and backgrounds.” </p>
-                        <p style="font-size:14px;">— Travis L. Scholten, IBM Quantum </p>
-                        <p class="subtitle"><a name="advisors" class="leading-arrow">Advisors</a></p>
-                        <p> Thanks to the <a href="posts/advisory_board.html" target="_blank">Advisory Board</a> for helping source and review applications! <br><br> Alex McCaskey, Amira Abbas, Amy Brown, Cassandra Granade, Christa Zoufal, Josh Izaac, Stephen DiAdamo, Mark Fingerhuth, Michał
-                            Stęchły, Nathan Killoran, Ntwali Bashige, Peter Karalekas, Roger Luo, Shahnawaz Ahmed, Hannah Sim, Tomas Babej, Travis L. Scholten </p>
-                        <p class="subtitle"><a name="team" class="leading-arrow">Unitary Fund Team</a></p>
-                            <a href="https://www.sckaiser.com/">Sarah Kaiser</a>, <a href="https://www.ryanlarose.com/">Ryan LaRose</a>, <a href="https://sites.google.com/site/andreamari84/">Andrea Mari</a>, <a href="https://nathanshammah.com/">Nathan Shammah</a>,
-                            <a href="https://github.com/wrathfulspatula">Daniel Strano</a>, <a href="https://github.com/vprusso">Vincent Russo</a>, 
-                            <a href="https://github.com/Misty-W">Misty Wahl</a>, <a href="https://natestemen.xyz">Nate Stemen</a>, Alowina Yap, <a href="https://uxfol.io/francespoblete">Frances Poblete</a>, & <a href="http://willzeng.com/"
-                                target="_blank">Will Zeng</a>.
-                            <footer class="footer leading-arrow light-arrow"> This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
-                                of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request! <br>
-                                <br>
-                                <table>
-                                    <tr>
-                                        <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                                class="fa fa-twitter"></i></a>
-                                        </th>
-                                        <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                                class="fa fa-twitch"></i></a>
-                                        </th>
-                                        <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                                class="fa fa-youtube"></i></a>
-                                        </th>
-                                        <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                                class="fab fa-discord"></i></a>
-                                        </th>
-                                    </tr>
-                                </table> &copy;2020 Unitary Fund
-                            </footer>
+              <p>We do three main things:</p>
+              <ul style="list-style-type: none">
+                <li class="leading-block">
+                  <b>We run a microgrant program</b> to fund <a href="grants.html">explorers</a> across the world to
+                  work on quantum technologies. Do you have an idea for a project?
+                  <a
+                    href="https://unitaryfund.typeform.com/to/j0kAOd"
+                    target="_blank"
+                    style="background-color: var(--color-yellow)"
+                    >Apply for a microgrant</a
+                  >. See our <a href="faq.html">FAQ</a> and <a href="grants.html">previous grants</a>.
+                </li>
+                <li class="leading-block">
+                  <b>We do our own research</b> to help the ecosystem as a whole. For example, we are developing
+                  <a href="mitiq.html" target="_blank" style="background-color: var(--color-yellow)">mitiq</a>, an open
+                  source compiler for error-mitigated quantum programming.
+                </li>
+                <li class="leading-block">
+                  <b>We host an open source quantum tech community</b> that runs
+                  <a href="https://unitaryfund.github.io/unitaryhack/">hackathons</a>
+                  and events on our
+                  <a href="http://discord.unitary.fund">Discord</a>.
+                  <a style="background-color: var(--color-yellow)" href="talks.html"> 📅 Calendar</a>
+                </li>
+              </ul>
+              <p>
+                We give <b>$4k</b> cash grants to quantum tech <a href="grants.html">projects</a>. Projects could be
+                open source quantum software, educational materials and workshops, a new quantum sensor prototype, or
+                much more.
+              </p>
+              <p>
+                Our program is designed to be as simple as possible. No organizational affiliation required. Just a
+                short form and a two minute video.
+              </p>
+              For more information or to check on your application email
+              <a href="mailto:info@unitary.fund">info@unitary.fund</a>.
+              <p>
+                Through our partners, we offer free credits to run on Rigetti's
+                <a href="https://docs.rigetti.com/en/">Quantum Cloud Services</a>
+                and priority-tier access to
+                <a href="https://www.ibm.com/quantum-computing/technology/systems">IBMQ's publicly available devices</a
+                >.
+              </p>
+              <p>
+                Read our
+                <a
+                  href="assets/Unitary_Fund_2021_Report.pdf"
+                  style="background-color: var(--color-yellow)"
+                  name="2021-report"
+                  >2021 Annual Report</a
+                >
+                and see what we got up to last year.
+              </p>
+              <p>
+                Unitary Fund is built to help the quantum industry, in a small way, to cross the chasm. We
+                <a
+                  href="https://medium.com/@wjzeng/the-unitary-fund-get-2-000-for-your-open-source-quantum-computing-project-d4b4c76ba177"
+                  target="_blank"
+                  >started as a small microgrant program for open source quantum software projects</a
+                >.
+              </p>
+              <center>
+                <!-- Begin MailChimp Signup Form -->
+                <div id="mc_embed_signup">
+                  <form
+                    action="https://fund.us18.list-manage.com/subscribe/post?u=104796c75ced8350ebd01eebd&amp;id=a2c9e5ac2a"
+                    method="post"
+                    id="mc-embedded-subscribe-form"
+                    name="mc-embedded-subscribe-form"
+                    class="validate"
+                    target="_blank"
+                    novalidate>
+                    <div id="mc_embed_signup_scroll">
+                      <label for="mce-EMAIL">Stay updated on our work:</label><br /><br />
+                      <input type="email" value="my@email.com" name="EMAIL" class="email" id="mce-EMAIL" required />
+                      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                      <div style="position: absolute; left: -5000px" aria-hidden="true">
+                        <input type="text" name="b_104796c75ced8350ebd01eebd_a2c9e5ac2a" tabindex="-1" value="" />
+                      </div>
+                      <!--<div class="clear">-->
+                      <input
+                        type="submit"
+                        value="Subscribe"
+                        name="subscribe"
+                        id="mc-embedded-subscribe"
+                        class="button heavy square-button" />
+                      <!--</div>-->
                     </div>
-                    <div class="col-1" id="menu-container">
-                        <table style="width:auto; margin-right:0px; margin-left: auto;">
-                            <tr>
-                                <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                            class="fa fa-twitter"></i></a></th>
-                                <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                            class="fa fa-twitch"></i></a></th>
-                                <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                            class="fa fa-youtube"></i></a></th>
-                                <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                            class="fab fa-discord"></i></a></th>
-                            </tr>
-                        </table>
-                        <p class="light" id="menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                    <div id="mobile-menu-container">
-                        <p class="light" id="mobile-menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
+                  </form>
                 </div>
-            </section>
-        </main>
+              </center>
+              <!--End mc_embed_signup-->
+              <a href="http://discord.unitary.fund" name="discord">
+                <figure>
+                  <img
+                    style="max-width: 100%; height: auto; margin: auto; display: block"
+                    src="./logos/discord-banner.png"
+                    alt="unitary-fund-discord" />
+                </figure>
+              </a>
+              <p class="subtitle leading-arrow">Supporters</p>
+              Learn more about our
+              <a href="https://unitary.fund/posts/2021-corporate-members.html" target="_blank"
+                >corporate membership program</a
+              >.
+              <ul style="list-style-type: none">
+                <li class="leading-block">
+                  <b>Core Members:</b>
+                  <a href="https://www.ibm.com/us-en/?ar=1">IBM</a> and
+                  <a href="https://www.accenture.com/us-en">Accenture</a>
+                </li>
+                <li class="leading-block">
+                  <b>Supporting Members:</b>
+                  <a href="https://xanadu.ai/">Xanadu</a>, <a href="https://ionq.com/">IonQ</a>,
+                  <a href="https://www.bcg.com/en-us/">Boston Consulting Group</a>,
+                  <a href="https://pasqal.io/">Pasqal</a>, <a href="https://www.meetiqm.com/">IQM</a>,
+                  <a href="https://hidorahacks.medium.com/">DoraHacks</a>,
+                  <a href="https://agnostiq.ai/">Agnostiq</a>
+                </li>
+                <li class="leading-block">
+                  <b>Other Supporters:</b>
+                  <a href="https://x.company/">Alphabet X (formerly Google X)</a>,
+                  <a href="https://www.microsoft.com/en-us/">Microsoft</a>,
+                  <a href="https://cambridgequantum.com/">Cambridge Quantum Computing</a>,
+                  <a href="https://www.rigetti.com/">Rigetti</a>,
+                  <a href="https://www.zapatacomputing.com/">Zapata Computing</a>,
+                  <a href="https://qcware.com/">QCWare</a>,
+                  <a href="http://quantumcomputing.com/">quantumcomputing.com</a>,
+                  <a href="https://strangeworks.com/">Strangeworks</a>,
+                  <a href="https://www.plos.org/" target="_blank">PLOS</a>,
+                  <a href="https://www.meetup.com/New-York-Quantum-Computing-Meetup/" target="_blank"
+                    >Steve Willis & NYC Quantum Meetup</a
+                  >, <a href="https://www.eeroq.com/" target="_blank">EeroQ</a>,
+                  <a href="https://twitter.com/johnhering" target="_blank">John Hering</a>, Jeff Cordova,
+                  <a href="https://twitter.com/nalidoust" target="_blank">Nima Alidoust</a>,
+                  <a href="https://www.ornl.gov/staff-profile/travis-s-humble" target="_blank">Travis Humble</a>, George
+                  Umbrarescu,
+                  <a href="https://www.zapatacomputing.com/team/greg-ramsay/" target="_blank">Greg Ramsay</a>,
+                  <a href="https://www.zapatacomputing.com/team/peter-johnson/" target="_blank">Peter Johnson</a>,
+                  <a href="https://twitter.com/quantumverd" target="_blank">Guillaume Verdon</a>,
+                  <a href="https://www.linkedin.com/in/rishisr33dhar/" target="_blank">Rishi Sreedhar</a>,
+                  <a href="https://twitter.com/Travis_Sch" target="_blank">Travis L. Scholten</a>,
+                  <a href="https://www.linkedin.com/in/amirebrahimi/" target="_blank">Amir Ebrahimi</a>,
+                  <a href="https://www.linkedin.com/in/christophe-jurczak" target="_blank">Christophe Jurczak</a>,
+                  <a href="https://twitter.com/wjzeng" target="_blank">Will Zeng</a>
+                </li>
+              </ul>
+              <center>
+                <p>
+                  <a
+                    href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NYN7D2ADDYQ78&source=url"
+                    style="background-color: var(--color-yellow)">
+                    Donate your support!
+                  </a>
+                </p>
+              </center>
+              <p style="font-size: 14px; font-style: italic">
+                “I imagine that years from now, some of the biggest contributors in quantum computing will have come
+                through the Unitary Fund program. The grants provide avenues for creative, motivated folks to
+                meaningfully contribute to this new industry. Awardees are using the program to launch their careers in
+                quantum computing, landing jobs at Zapata and elsewhere.”
+              </p>
+              <p style="font-size: 14px">—Peter Johnson, Co-Founder, Zapata Computing</p>
+              <p style="font-size: 14px; font-style: italic">
+                “Our support of the Unitary Fund enables continued growth of the quantum computing ecosystem. It is an
+                opportunity to connect with and help quantum developers from a diverse range of skill sets and
+                backgrounds.”
+              </p>
+              <p style="font-size: 14px">— Travis L. Scholten, IBM Quantum</p>
+              <p class="subtitle">
+                <a name="advisors" class="leading-arrow">Advisors</a>
+              </p>
+              <p>
+                Thanks to the
+                <a href="posts/advisory_board.html" target="_blank">Advisory Board</a>
+                for helping source and review applications! <br /><br />
+                Alex McCaskey, Amira Abbas, Amy Brown, Cassandra Granade, Christa Zoufal, Josh Izaac, Stephen DiAdamo,
+                Mark Fingerhuth, Michał Stęchły, Nathan Killoran, Ntwali Bashige, Peter Karalekas, Roger Luo, Shahnawaz
+                Ahmed, Hannah Sim, Tomas Babej, Travis L. Scholten
+              </p>
+              <p class="subtitle">
+                <a name="team" class="leading-arrow">Unitary Fund Team</a>
+              </p>
+              <a href="https://www.sckaiser.com/">Sarah Kaiser</a>,
+              <a href="https://www.ryanlarose.com/">Ryan LaRose</a>,
+              <a href="https://sites.google.com/site/andreamari84/">Andrea Mari</a>,
+              <a href="https://nathanshammah.com/">Nathan Shammah</a>,
+              <a href="https://github.com/wrathfulspatula">Daniel Strano</a>,
+              <a href="https://github.com/vprusso">Vincent Russo</a>,
+              <a href="https://github.com/Misty-W">Misty Wahl</a>, <a href="https://natestemen.xyz">Nate Stemen</a>,
+              Alowina Yap, <a href="https://uxfol.io/francespoblete">Frances Poblete</a>, &
+              <a href="http://willzeng.com/" target="_blank">Will Zeng</a>.
+              <footer class="footer leading-arrow light-arrow">
+                This website is hosted on
+                <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community
+                follows this
+                <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a
+                >. <br />
+                <br />
+                If you have suggestions for changes then please open up a pull request! <br />
+                <br />
+                <table>
+                  <tr>
+                    <th style="text-align: right">
+                      <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"
+                        ><i class="fa fa-youtube"></i
+                      ></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                    </th>
+                  </tr>
+                </table>
+                &copy;2020 Unitary Fund
+              </footer>
+            </div>
+            <div class="col-1" id="menu-container">
+              <table style="width: auto; margin-right: 0px; margin-left: auto">
+                <tr>
+                  <th style="text-align: right">
+                    <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                  </th>
+                </tr>
+              </table>
+              <p class="light" id="menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+            <div id="mobile-menu-container">
+              <p class="light" id="mobile-menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
     <script>
-        var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
-        mobileMenuContainer = document.querySelector("#mobile-menu-container");
-        mobileMenuIcon.addEventListener("click", function() {
-            mobileMenuIcon.classList.toggle("is-active");
-            mobileMenuContainer.classList.toggle("active");
-        });
+      var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
+      mobileMenuContainer = document.querySelector("#mobile-menu-container")
+      mobileMenuIcon.addEventListener("click", function () {
+        mobileMenuIcon.classList.toggle("is-active")
+        mobileMenuContainer.classList.toggle("active")
+      })
     </script>
-</body>
-
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                             <li class="leading-block"><b>We do our own research</b> to help the ecosystem as a whole. For example, we are developing <a href="mitiq.html" target="_blank" style="background-color:var(--color-yellow);">mitiq</a>, an open source compiler for error-mitigated
                                 quantum programming. </li>
                             <br>
-                            <li class="leading-block"><b>We host an open source quantum tech community</b> that runs <a href="https://unitaryfund.github.io/unitaryhack/">hackathons</a> and events on our <a href=http://discord.unitary.fund>Discord</a>.
+                            <li class="leading-block"><b>We host an open source quantum tech community</b> that runs <a href="https://unitaryfund.github.io/unitaryhack/">hackathons</a> and events on our <a href="http://discord.unitary.fund">Discord</a>.
                                 <a style="background-color:var(--color-yellow);" href="talks.html"> 📅 Calendar</a></li>
                         </ul>
                         <p>We give <b>$4k</b> cash grants to quantum tech <a href="grants.html">projects</a>. Projects could be open source quantum software, educational materials and workshops, a new quantum sensor prototype, or much more.</p>
@@ -114,7 +114,7 @@
                             <p class="subtitle leading-arrow">Supporters</p>
                             Learn more about our <a href="https://unitary.fund/posts/2021-corporate-members.html" target="_blank">corporate membership program</a>.
                             <ul style="list-style-type: none;">
-                                <li class="leading-block"><b>Core Members:</b> <a href="https://www.ibm.com/us-en/?ar=1">IBM</a> and <a href="https://www.accenture.com/us-en>">Accenture</a> </li>
+                                <li class="leading-block"><b>Core Members:</b> <a href="https://www.ibm.com/us-en/?ar=1">IBM</a> and <a href="https://www.accenture.com/us-en">Accenture</a> </li>
                                 <br>
                                 <li class="leading-block"><b>Supporting Members:</b> <a href="https://xanadu.ai/">Xanadu</a>, <a href="https://ionq.com/">IonQ</a>, <a href="https://www.bcg.com/en-us/">Boston Consulting Group</a>, <a href="https://pasqal.io/">Pasqal</a>,
                                     <a href="https://www.meetiqm.com/">IQM</a>, <a href="https://hidorahacks.medium.com/">DoraHacks</a>, <a href="https://agnostiq.ai/">Agnostiq</a>
@@ -122,19 +122,19 @@
                                 <br>
                                 <li class="leading-block"><b>Other Supporters:</b> <a href="https://x.company/">Alphabet X
                                     (formerly Google X)</a>, <a href="https://www.microsoft.com/en-us/">Microsoft</a>, <a href="https://cambridgequantum.com/">Cambridge Quantum Computing</a>, <a href="https://www.rigetti.com/">Rigetti</a>, <a href="https://www.zapatacomputing.com/">Zapata Computing</a>,
-                                    <a href="https://qcware.com/">QCWare</a>, <a href="http://quantumcomputing.com/">quantumcomputing.com</a>, <a href="https://strangeworks.com/">Strangeworks</a>, <a href="https://www.plos.org/" , target="_blank">PLOS</a>,
-                                    <a href="https://www.meetup.com/New-York-Quantum-Computing-Meetup/" , target="_blank">Steve
-                                        Willis & NYC Quantum Meetup</a>, <a href="https://www.eeroq.com/" , target="_blank">EeroQ</a>, <a href="https://twitter.com/johnhering" , target="_blank">John
-                                        Hering</a>, Jeff Cordova, <a href="https://twitter.com/nalidoust" , target="_blank">Nima
-                                        Alidoust</a>, <a href="https://www.ornl.gov/staff-profile/travis-s-humble" , target="_blank">Travis Humble</a>, George Umbrarescu,
-                                    <a href="https://www.zapatacomputing.com/team/greg-ramsay/" , target="_blank">Greg Ramsay</a>,
-                                    <a href="https://www.zapatacomputing.com/team/peter-johnson/" , target="_blank">Peter Johnson</a>,
-                                    <a href="https://twitter.com/quantumverd" , target="_blank">Guillaume Verdon</a>,
-                                    <a href="https://www.linkedin.com/in/rishisr33dhar/" , target="_blank">Rishi Sreedhar</a>,
-                                    <a href="https://twitter.com/Travis_Sch" , target="_blank">Travis L. Scholten</a>,
-                                    <a href="https://www.linkedin.com/in/amirebrahimi/" , target="_blank">Amir Ebrahimi</a>,
-                                    <a href="https://www.linkedin.com/in/christophe-jurczak" , target="_blank">Christophe Jurczak</a>,
-                                    <a href="https://twitter.com/wjzeng" , target="_blank">Will Zeng</a></li>
+                                    <a href="https://qcware.com/">QCWare</a>, <a href="http://quantumcomputing.com/">quantumcomputing.com</a>, <a href="https://strangeworks.com/">Strangeworks</a>, <a href="https://www.plos.org/" target="_blank">PLOS</a>,
+                                    <a href="https://www.meetup.com/New-York-Quantum-Computing-Meetup/" target="_blank">Steve
+                                        Willis & NYC Quantum Meetup</a>, <a href="https://www.eeroq.com/" target="_blank">EeroQ</a>, <a href="https://twitter.com/johnhering" target="_blank">John
+                                        Hering</a>, Jeff Cordova, <a href="https://twitter.com/nalidoust" target="_blank">Nima
+                                        Alidoust</a>, <a href="https://www.ornl.gov/staff-profile/travis-s-humble" target="_blank">Travis Humble</a>, George Umbrarescu,
+                                    <a href="https://www.zapatacomputing.com/team/greg-ramsay/" target="_blank">Greg Ramsay</a>,
+                                    <a href="https://www.zapatacomputing.com/team/peter-johnson/" target="_blank">Peter Johnson</a>,
+                                    <a href="https://twitter.com/quantumverd" target="_blank">Guillaume Verdon</a>,
+                                    <a href="https://www.linkedin.com/in/rishisr33dhar/" target="_blank">Rishi Sreedhar</a>,
+                                    <a href="https://twitter.com/Travis_Sch" target="_blank">Travis L. Scholten</a>,
+                                    <a href="https://www.linkedin.com/in/amirebrahimi/" target="_blank">Amir Ebrahimi</a>,
+                                    <a href="https://www.linkedin.com/in/christophe-jurczak" target="_blank">Christophe Jurczak</a>,
+                                    <a href="https://twitter.com/wjzeng" target="_blank">Will Zeng</a></li>
                             </ul>
                         </p>
                         <center>
@@ -148,14 +148,14 @@
                         <p style="font-size:14px; font-style:italic">“Our support of the Unitary Fund enables continued growth of the quantum computing ecosystem. It is an opportunity to connect with and help quantum developers from a diverse range of skill sets and backgrounds.” </p>
                         <p style="font-size:14px;">— Travis L. Scholten, IBM Quantum </p>
                         <p class="subtitle"><a name="advisors" class="leading-arrow">Advisors</a></p>
-                        <p> Thanks to the <a href="posts/advisory_board.html" , target="_blank">Advisory Board</a> for helping source and review applications! <br><br> Alex McCaskey, Amira Abbas, Amy Brown, Cassandra Granade, Christa Zoufal, Josh Izaac, Stephen DiAdamo, Mark Fingerhuth, Michał
+                        <p> Thanks to the <a href="posts/advisory_board.html" target="_blank">Advisory Board</a> for helping source and review applications! <br><br> Alex McCaskey, Amira Abbas, Amy Brown, Cassandra Granade, Christa Zoufal, Josh Izaac, Stephen DiAdamo, Mark Fingerhuth, Michał
                             Stęchły, Nathan Killoran, Ntwali Bashige, Peter Karalekas, Roger Luo, Shahnawaz Ahmed, Hannah Sim, Tomas Babej, Travis L. Scholten </p>
                         <p class="subtitle"><a name="team" class="leading-arrow">Unitary Fund Team</a></p>
                         <a>
                             <a href="https://www.sckaiser.com/">Sarah Kaiser</a>, <a href="https://www.ryanlarose.com/">Ryan LaRose</a>, <a href="https://sites.google.com/site/andreamari84/">Andrea Mari</a>, <a href="https://nathanshammah.com/">Nathan Shammah</a>,
                             <a href="https://github.com/wrathfulspatula">Daniel Strano</a>, <a href="https://github.com/vprusso">Vincent Russo</a>, 
                             <a href="https://github.com/Misty-W">Misty Wahl</a>, <a href="https://natestemen.xyz">Nate Stemen</a>, Alowina Yap, <a href="https://uxfol.io/francespoblete">Frances Poblete</a>, & <a href="http://willzeng.com/"
-                                , target="_blank">Will Zeng</a>.
+                                target="_blank">Will Zeng</a>.
                             </p>
                             <footer class="footer leading-arrow light-arrow"> This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
                                 of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request! <br>

--- a/meetup.html
+++ b/meetup.html
@@ -53,7 +53,7 @@
                 <div class="container">
                     <div class="col-3">
                         <div class="hero">
-                            <a href="/"><img src="/logos/logov3.svg" alt="Unitary Fund" /></a>
+                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
                             <p class="tagline"><b>Because evolution is
                                     <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
                                         target="_blank">unitary</a></b>.</p>

--- a/meetup.html
+++ b/meetup.html
@@ -75,7 +75,7 @@
                         <strong>Join a Quantum Software Meetup: <a href="https://gather.town/invite?token=GnXT4luY">unitary.fund/meetup</a></strong>
 
                         <p class="subtitle leading-arrow">Upcoming meetings</p>
-                        <ul id="seminar-list" style="list-style-type: none;">
+                        <ul style="list-style-type: none;">
                             <li class="leading-block"><span class="blog-post-date">21 September, 2021 - 12pm EST/5pm GMT</span><br>
                                 <a href="https://gather.town/invite?token=GnXT4luY"><img src="/images/quantum-software-meetup.png" alt="QSM kickoff advertisement card" id="QSMkickoff" /></a>
                             </li>

--- a/meetup.html
+++ b/meetup.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 
 <html>
-<script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -32,6 +31,7 @@
         }
     </style>
 
+    <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>

--- a/meetup.html
+++ b/meetup.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/meetup.html
+++ b/meetup.html
@@ -1,157 +1,192 @@
 <!DOCTYPE html>
 
 <html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
 
     <title>Unitary Fund</title>
     <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="style.css">
-    <link rel="stylesheet" type="text/css" href="hamburgers.min.css">
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
-    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-        #mc_embed_signup {
-            background: #fff;
-            clear: left;
-            font: 14px "Lucida Console", Monaco, monospace;
-            width: 100%;
-        }
-        
-        #mce-EMAIL {
-            padding: 11px;
-            margin: 10px;
-        }
+      #mc_embed_signup {
+        background: #fff;
+        clear: left;
+        font: 14px "Lucida Console", Monaco, monospace;
+        width: 100%;
+      }
+
+      #mce-EMAIL {
+        padding: 11px;
+        margin: 10px;
+      }
     </style>
 
     <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
+      window.dataLayer = window.dataLayer || []
 
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-        gtag('config', 'UA-19932157-4');
+      gtag("config", "UA-19932157-4")
     </script>
-</head>
+  </head>
 
-<body>
+  <body>
     <div class="layout">
-        <main id="content" class="content">
-            <section class="heavy">
-                <div class="container">
-                    <div class="col-3">
-                        <div class="hero">
-                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
-                            <p class="tagline"><b>Because evolution is
-                                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
-                                        target="_blank">unitary</a></b>.</p>
-                            <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
-                                <span class="hamburger-box">
-                                    <span class="hamburger-inner"></span>
-                                </span>
-                            </button>
-                        </div>
-                        <p class="subtitle leading-arrow">Quantum Software Meetup</p>
-                        <h4>Co-hosted with the <a href="https://qosf.org/">Quantum Open Source Foundation</a></h4>
-                        The quantum open source software community is growing as fast as we can build and develop new quantum technologies. With so many different tools, frameworks, languages, and devices out there to play with, we wanted to find a way to help folks interested
-                        in designing, building and using quantum software network and learn what amazing things are being developed. The <strong>Quantum Software Meetup</strong> is a group to address the growing need for connection
-                        and collaboration between quantum software developers, researchers, and users. We will be hosting a meetup every month to discuss new technologies, share resources, and build a community passionate about quantum software. The meetings
-                        will be similar in format to other meetups, but to facilitate a global audience they will be hosted on <a href="https://www.gather.town/">Gather</a>. We will have a few short talks to kick off the meeting, and then have social
-                        time to meet the people and projects that make up the quantum software community.
-                        <br>
-                        <br>
-                        <strong>Join a Quantum Software Meetup: <a href="https://gather.town/invite?token=GnXT4luY">unitary.fund/meetup</a></strong>
+      <main id="content" class="content">
+        <section class="heavy">
+          <div class="container">
+            <div class="col-3">
+              <div class="hero">
+                <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
+                <p class="tagline">
+                  <b
+                    >Because evolution is
+                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b
+                  >.
+                </p>
+                <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
+                  <span class="hamburger-box">
+                    <span class="hamburger-inner"></span>
+                  </span>
+                </button>
+              </div>
+              <p class="subtitle leading-arrow">Quantum Software Meetup</p>
+              <h4>
+                Co-hosted with the
+                <a href="https://qosf.org/">Quantum Open Source Foundation</a>
+              </h4>
+              The quantum open source software community is growing as fast as we can build and develop new quantum
+              technologies. With so many different tools, frameworks, languages, and devices out there to play with, we
+              wanted to find a way to help folks interested in designing, building and using quantum software network
+              and learn what amazing things are being developed. The
+              <strong>Quantum Software Meetup</strong> is a group to address the growing need for connection and
+              collaboration between quantum software developers, researchers, and users. We will be hosting a meetup
+              every month to discuss new technologies, share resources, and build a community passionate about quantum
+              software. The meetings will be similar in format to other meetups, but to facilitate a global audience
+              they will be hosted on <a href="https://www.gather.town/">Gather</a>. We will have a few short talks to
+              kick off the meeting, and then have social time to meet the people and projects that make up the quantum
+              software community.
+              <br />
+              <br />
+              <strong
+                >Join a Quantum Software Meetup:
+                <a href="https://gather.town/invite?token=GnXT4luY">unitary.fund/meetup</a></strong
+              >
 
-                        <p class="subtitle leading-arrow">Upcoming meetings</p>
-                        <ul style="list-style-type: none;">
-                            <li class="leading-block"><span class="blog-post-date">21 September, 2021 - 12pm EST/5pm GMT</span><br>
-                                <a href="https://gather.town/invite?token=GnXT4luY"><img src="/images/quantum-software-meetup.png" alt="QSM kickoff advertisement card" id="QSMkickoff" /></a>
-                            </li>
-                        </ul>
+              <p class="subtitle leading-arrow">Upcoming meetings</p>
+              <ul style="list-style-type: none">
+                <li class="leading-block">
+                  <span class="blog-post-date">21 September, 2021 - 12pm EST/5pm GMT</span><br />
+                  <a href="https://gather.town/invite?token=GnXT4luY"
+                    ><img
+                      src="/images/quantum-software-meetup.png"
+                      alt="QSM kickoff advertisement card"
+                      id="QSMkickoff"
+                  /></a>
+                </li>
+              </ul>
 
-                        <footer class="footer leading-arrow light-arrow">
-                            This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
-                                of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request!
-                            <br>
-                            <br>
-                            <table>
-                                <tr>
-                                    <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                                class="fa fa-twitter"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                                class="fa fa-twitch"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                                class="fa fa-youtube"></i></a></th>
-                                    <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                                class="fab fa-discord"></i></a></th>
-                                </tr>
-                            </table> &copy;2020 Unitary Fund
-                        </footer>
-                    </div>
-                    <div class="col-1" id="menu-container">
-                        <table style="width:auto; margin-right:0px; margin-left: auto;">
-                            <tr>
-                                <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                            class="fa fa-twitter"></i></a></th>
-                                <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                            class="fa fa-twitch"></i></a></th>
-                                <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                            class="fa fa-youtube"></i></a></th>
-                                <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                            class="fab fa-discord"></i></a></th>
-                            </tr>
-                        </table>
-                        <p class="light" id="menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html" class="active">ideas</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                    <div id="mobile-menu-container">
-                        <p class="light" id="mobile-menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html" class="active">ideas</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                </div>
-            </section>
-        </main>
+              <footer class="footer leading-arrow light-arrow">
+                This website is hosted on
+                <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community
+                follows this
+                <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a
+                >. <br />
+                <br />
+                If you have suggestions for changes then please open up a pull request!
+                <br />
+                <br />
+                <table>
+                  <tr>
+                    <th style="text-align: right">
+                      <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"
+                        ><i class="fa fa-youtube"></i
+                      ></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                    </th>
+                  </tr>
+                </table>
+                &copy;2020 Unitary Fund
+              </footer>
+            </div>
+            <div class="col-1" id="menu-container">
+              <table style="width: auto; margin-right: 0px; margin-left: auto">
+                <tr>
+                  <th style="text-align: right">
+                    <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                  </th>
+                </tr>
+              </table>
+              <p class="light" id="menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html" class="active">ideas</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+            <div id="mobile-menu-container">
+              <p class="light" id="mobile-menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html" class="active">ideas</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
     <script>
-        var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
-        mobileMenuContainer = document.querySelector("#mobile-menu-container");
-        mobileMenuIcon.addEventListener("click", function() {
-            mobileMenuIcon.classList.toggle("is-active");
-            mobileMenuContainer.classList.toggle("active");
-        });
+      var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
+      mobileMenuContainer = document.querySelector("#mobile-menu-container")
+      mobileMenuIcon.addEventListener("click", function () {
+        mobileMenuIcon.classList.toggle("is-active")
+        mobileMenuContainer.classList.toggle("active")
+      })
     </script>
-</body>
-
+  </body>
 </html>

--- a/meetup.html
+++ b/meetup.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
-    <style type="text/css">
+    <style>
       #mc_embed_signup {
         background: #fff;
         clear: left;

--- a/mitiq.html
+++ b/mitiq.html
@@ -47,30 +47,29 @@
     <script src="https://static.airtable.com/js/embed/embed_snippet_v1.js"></script>
     <style>
     #sign-up-button {
-            float: right;
-            text-decoration: none;
-            text-transform: uppercase;
-            font-size: var(--type-x-small);
-            background-color: var(--color-black);
-            color: var(--color-white);
-            padding: var(--space-x-small) var(--space-small);
-        }
-        
-        .video-container {
-            display: flex;
-        }
-        
-        .video-container .col-1-3 {
-            width: 33.33%;
-        }
-        
-        .video-container .col-2-3 {
-            width: 66.66%;
-        }
-        
-        .video-container video {
-            width: 100%;
-        }
+        float: right;
+        text-decoration: none;
+        text-transform: uppercase;
+        font-size: var(--type-x-small);
+        background-color: var(--color-black);
+        color: var(--color-white);
+        padding: var(--space-x-small) var(--space-small);
+    }
+    
+    .video-container {
+        display: flex;
+    }
+    
+    .video-container .col-1-3 {
+        width: 33.33%;
+    }
+    
+    .video-container .col-2-3 {
+        width: 66.66%;
+    }
+    
+    .video-container video {
+        width: 100%;
     }
     </style>
 </head>

--- a/mitiq.html
+++ b/mitiq.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 
 <html>
-<script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -32,6 +31,7 @@
         }
     </style>
 
+    <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>

--- a/mitiq.html
+++ b/mitiq.html
@@ -144,7 +144,8 @@
                 title="YouTube video player"
                 style="border: none"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowfullscreen></iframe>
+                allowfullscreen
+              ></iframe>
 
               <footer class="footer leading-arrow light-arrow">
                 This website is hosted on

--- a/mitiq.html
+++ b/mitiq.html
@@ -1,52 +1,51 @@
 <!DOCTYPE html>
 
 <html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
 
     <title>Unitary Fund</title>
     <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="style.css">
-    <link rel="stylesheet" type="text/css" href="hamburgers.min.css">
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
-    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-        #mc_embed_signup {
-            background: #fff;
-            clear: left;
-            font: 14px "Lucida Console", Monaco, monospace;
-            width: 100%;
-        }
-        
-        #mce-EMAIL {
-            padding: 11px;
-            margin: 10px;
-        }
+      #mc_embed_signup {
+        background: #fff;
+        clear: left;
+        font: 14px "Lucida Console", Monaco, monospace;
+        width: 100%;
+      }
+
+      #mce-EMAIL {
+        padding: 11px;
+        margin: 10px;
+      }
     </style>
 
     <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
+      window.dataLayer = window.dataLayer || []
 
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-        gtag('config', 'UA-19932157-4');
+      gtag("config", "UA-19932157-4")
     </script>
     <script src="https://static.airtable.com/js/embed/embed_snippet_v1.js"></script>
     <style>
-    #sign-up-button {
+      #sign-up-button {
         float: right;
         text-decoration: none;
         text-transform: uppercase;
@@ -54,156 +53,187 @@
         background-color: var(--color-black);
         color: var(--color-white);
         padding: var(--space-x-small) var(--space-small);
-    }
-    
-    .video-container {
+      }
+
+      .video-container {
         display: flex;
-    }
-    
-    .video-container .col-1-3 {
+      }
+
+      .video-container .col-1-3 {
         width: 33.33%;
-    }
-    
-    .video-container .col-2-3 {
+      }
+
+      .video-container .col-2-3 {
         width: 66.66%;
-    }
-    
-    .video-container video {
+      }
+
+      .video-container video {
         width: 100%;
-    }
+      }
     </style>
-</head>
+  </head>
 
-<body>
+  <body>
     <div class="layout">
-        <main id="content" class="content">
-            <section class="heavy">
-                <div class="container">
-                    <div class="col-3">
-                        <div class="hero">
-                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
-                            <p class="tagline"><b>Because evolution is
-                                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
-                                        target="_blank">unitary</a></b>.</p>
-                            <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
-                                <span class="hamburger-box">
-                                    <span class="hamburger-inner"></span>
-                                </span>
-                            </button>
-                        </div>
-                        <p class="subtitle leading-arrow">Quantum computers have errors</p>
-                        <p><b style="background-color:var(--color-yellow);"><a
-                                    href="https://github.com/unitaryfund/mitiq">Mitiq</a></b> is a cross platform compiler that makes your programs robust to those errors.</p>
-                        <div class="video-container">
-                            <div class="col-2-3">
-                                <video autoplay muted loop>
-                                    <source src="assets/qiskit.mp4" type="video/mp4">
-                                </video>
-                            </div>
-                            <div class="col-1-3" style="padding-left: var(--space-small); font-size: var(--type-small)">
-                                <img src="images/qiskit.png" alt="Qiskit">
-                                <p style="margin: 0;">Mitigating errors with Qiskit</p>
-                            </div>
-                        </div>
-                        <div class="video-container">
-                            <div class="col-2-3">
-                                <video autoplay muted loop>
-                                    <source src="assets/cirq.mp4" type="video/mp4">
-                                </video>
-                            </div>
-                            <div class="col-1-3" style="padding-left: var(--space-small); font-size: var(--type-small)">
-                                <img src="images/cirq.png" alt="Cirq">
-                                <p style="margin: 0;">Mitigating errors with Cirq</p>
-                            </div>
-                        </div>
-
-                        <p class="subtitle leading-arrow">Want help using mitiq?</p>
-                        You can find us in the #mitiq channel on our <b style="background-color:var(--color-yellow);"><a
-                                href="http://discord.unitary.fund">discord</a></b> or email us at <a href="mailto:mitiq@unitary.fund">mitiq@unitary.fund</a>.
-
-                        <p class="subtitle leading-arrow">Learn more about Mitiq</p>
-                        <p>Read our <b><a href="https://arxiv.org/abs/2009.04417">whitepaper</a></b>, check out our
-                            <b><a href="https://mitiq.readthedocs.io/en/stable/">documentation</a></b>, or watch the video below.
-                        </p>
-
-                        <iframe width="560" height="315" src="https://www.youtube.com/embed/QK3Vkn2MCCg?start=558" title="YouTube video player" style="border: none;" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-                        <footer class="footer leading-arrow light-arrow">
-                            This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
-                                of conduct</a>.
-                            <br> <br> If you have suggestions for changes then please open up a pull request!
-                            <br>
-                            <br>
-                            <table>
-                                <tr>
-                                    <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                                class="fa fa-twitter"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                                class="fa fa-twitch"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                                class="fa fa-youtube"></i></a></th>
-                                    <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                                class="fab fa-discord"></i></a></th>
-                                </tr>
-                            </table> &copy;2020 Unitary Fund
-                        </footer>
-                    </div>
-                    <div class="col-1" id="menu-container">
-                        <table style="width:auto; margin-right:0px; margin-left: auto;">
-                            <tr>
-                                <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                            class="fa fa-twitter"></i></a></th>
-                                <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                            class="fa fa-twitch"></i></a>
-                                </th>
-                                <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                            class="fa fa-youtube"></i></a></th>
-                                <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                            class="fab fa-discord"></i></a>
-                                </th>
-                            </tr>
-                        </table>
-                        <p class="light" id="menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html" class="active">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                    <div id="mobile-menu-container">
-                        <p class="light" id="mobile-menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html" class="active">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
+      <main id="content" class="content">
+        <section class="heavy">
+          <div class="container">
+            <div class="col-3">
+              <div class="hero">
+                <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
+                <p class="tagline">
+                  <b
+                    >Because evolution is
+                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b
+                  >.
+                </p>
+                <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
+                  <span class="hamburger-box">
+                    <span class="hamburger-inner"></span>
+                  </span>
+                </button>
+              </div>
+              <p class="subtitle leading-arrow">Quantum computers have errors</p>
+              <p>
+                <b style="background-color: var(--color-yellow)"
+                  ><a href="https://github.com/unitaryfund/mitiq">Mitiq</a></b
+                >
+                is a cross platform compiler that makes your programs robust to those errors.
+              </p>
+              <div class="video-container">
+                <div class="col-2-3">
+                  <video autoplay muted loop>
+                    <source src="assets/qiskit.mp4" type="video/mp4" />
+                  </video>
                 </div>
-            </section>
-        </main>
+                <div class="col-1-3" style="padding-left: var(--space-small); font-size: var(--type-small)">
+                  <img src="images/qiskit.png" alt="Qiskit" />
+                  <p style="margin: 0">Mitigating errors with Qiskit</p>
+                </div>
+              </div>
+              <div class="video-container">
+                <div class="col-2-3">
+                  <video autoplay muted loop>
+                    <source src="assets/cirq.mp4" type="video/mp4" />
+                  </video>
+                </div>
+                <div class="col-1-3" style="padding-left: var(--space-small); font-size: var(--type-small)">
+                  <img src="images/cirq.png" alt="Cirq" />
+                  <p style="margin: 0">Mitigating errors with Cirq</p>
+                </div>
+              </div>
+
+              <p class="subtitle leading-arrow">Want help using mitiq?</p>
+              You can find us in the #mitiq channel on our
+              <b style="background-color: var(--color-yellow)"><a href="http://discord.unitary.fund">discord</a></b>
+              or email us at
+              <a href="mailto:mitiq@unitary.fund">mitiq@unitary.fund</a>.
+
+              <p class="subtitle leading-arrow">Learn more about Mitiq</p>
+              <p>
+                Read our
+                <b><a href="https://arxiv.org/abs/2009.04417">whitepaper</a></b
+                >, check out our <b><a href="https://mitiq.readthedocs.io/en/stable/">documentation</a></b
+                >, or watch the video below.
+              </p>
+
+              <iframe
+                width="560"
+                height="315"
+                src="https://www.youtube.com/embed/QK3Vkn2MCCg?start=558"
+                title="YouTube video player"
+                style="border: none"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen></iframe>
+
+              <footer class="footer leading-arrow light-arrow">
+                This website is hosted on
+                <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community
+                follows this
+                <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a
+                >. <br />
+                <br />
+                If you have suggestions for changes then please open up a pull request!
+                <br />
+                <br />
+                <table>
+                  <tr>
+                    <th style="text-align: right">
+                      <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"
+                        ><i class="fa fa-youtube"></i
+                      ></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                    </th>
+                  </tr>
+                </table>
+                &copy;2020 Unitary Fund
+              </footer>
+            </div>
+            <div class="col-1" id="menu-container">
+              <table style="width: auto; margin-right: 0px; margin-left: auto">
+                <tr>
+                  <th style="text-align: right">
+                    <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                  </th>
+                </tr>
+              </table>
+              <p class="light" id="menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html" class="active">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+            <div id="mobile-menu-container">
+              <p class="light" id="mobile-menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html" class="active">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
     <script>
-        var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
-        mobileMenuContainer = document.querySelector("#mobile-menu-container");
-        mobileMenuIcon.addEventListener("click", function() {
-            mobileMenuIcon.classList.toggle("is-active");
-            mobileMenuContainer.classList.toggle("active");
-        });
+      var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
+      mobileMenuContainer = document.querySelector("#mobile-menu-container")
+      mobileMenuIcon.addEventListener("click", function () {
+        mobileMenuIcon.classList.toggle("is-active")
+        mobileMenuContainer.classList.toggle("active")
+      })
     </script>
-</body>
-
+  </body>
 </html>

--- a/mitiq.html
+++ b/mitiq.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/mitiq.html
+++ b/mitiq.html
@@ -82,7 +82,7 @@
                 <div class="container">
                     <div class="col-3">
                         <div class="hero">
-                            <a href="/"><img src="/logos/logov3.svg" alt="Unitary Fund" /></a>
+                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
                             <p class="tagline"><b>Because evolution is
                                     <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
                                         target="_blank">unitary</a></b>.</p>
@@ -98,22 +98,22 @@
                         <div class="video-container">
                             <div class="col-2-3">
                                 <video autoplay muted loop>
-                                    <source src="/assets/qiskit.mp4" type="video/mp4">
+                                    <source src="assets/qiskit.mp4" type="video/mp4">
                                 </video>
                             </div>
                             <div class="col-1-3" style="padding-left: var(--space-small); font-size: var(--type-small)">
-                                <img src="/images/qiskit.png" alt="Qiskit">
+                                <img src="images/qiskit.png" alt="Qiskit">
                                 <p style="margin: 0;">Mitigating errors with Qiskit</p>
                             </div>
                         </div>
                         <div class="video-container">
                             <div class="col-2-3">
                                 <video autoplay muted loop>
-                                    <source src="../assets/cirq.mp4" type="video/mp4">
+                                    <source src="assets/cirq.mp4" type="video/mp4">
                                 </video>
                             </div>
                             <div class="col-1-3" style="padding-left: var(--space-small); font-size: var(--type-small)">
-                                <img src="/images/cirq.png" alt="Cirq">
+                                <img src="images/cirq.png" alt="Cirq">
                                 <p style="margin: 0;">Mitigating errors with Cirq</p>
                             </div>
                         </div>

--- a/mitiq.html
+++ b/mitiq.html
@@ -126,7 +126,7 @@
                             <b><a href="https://mitiq.readthedocs.io/en/stable/">documentation</a></b>, or watch the video below.
                         </p>
 
-                        <iframe width="560" height="315" src="https://www.youtube.com/embed/QK3Vkn2MCCg?start=558" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                        <iframe width="560" height="315" src="https://www.youtube.com/embed/QK3Vkn2MCCg?start=558" title="YouTube video player" style="border: none;" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
                         <footer class="footer leading-arrow light-arrow">
                             This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code

--- a/mitiq.html
+++ b/mitiq.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
-    <style type="text/css">
+    <style>
       #mc_embed_signup {
         background: #fff;
         clear: left;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew=="
+    }
+  }
+}

--- a/research.html
+++ b/research.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" type="text/css" href="style.css" />
     <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
-    <style type="text/css">
+    <style>
       #mc_embed_signup {
         background: #fff;
         clear: left;

--- a/research.html
+++ b/research.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/research.html
+++ b/research.html
@@ -1,211 +1,349 @@
 <!DOCTYPE html>
 <html>
-
-<head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="/favicon/site.webmanifest">
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
     <title>Unitary Fund</title>
     <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="style.css">
-    <link rel="stylesheet" type="text/css" href="hamburgers.min.css">
-    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
+    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-        #mc_embed_signup {
-            background: #fff;
-            clear: left;
-            font: 14px "Lucida Console", Monaco, monospace;
-            width: 100%;
-        }
-        
-        #mce-EMAIL {
-            padding: 11px;
-            margin: 10px;
-        }
+      #mc_embed_signup {
+        background: #fff;
+        clear: left;
+        font: 14px "Lucida Console", Monaco, monospace;
+        width: 100%;
+      }
+
+      #mce-EMAIL {
+        padding: 11px;
+        margin: 10px;
+      }
     </style>
     <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
+      window.dataLayer = window.dataLayer || []
 
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-        gtag('config', 'UA-19932157-4');
+      gtag("config", "UA-19932157-4")
     </script>
     <script src="https://static.airtable.com/js/embed/embed_snippet_v1.js"></script>
     <style>
-    #sign-up-button {
-            float: right;
-            text-decoration: none;
-            text-transform: uppercase;
-            font-size: var(--type-x-small);
-            background-color: var(--color-black);
-            color: var(--color-white);
-            padding: var(--space-x-small) var(--space-small);
-        }
-        
-        .video-container {
-            display: flex;
-        }
-        
-        .video-container .col-1-3 {
-            width: 33.33%;
-        }
-        
-        .video-container .col-2-3 {
-            width: 66.66%;
-        }
-        
-        .video-container video {
-            width: 100%;
-        }
-    
-    </style>
-</head>
+      #sign-up-button {
+        float: right;
+        text-decoration: none;
+        text-transform: uppercase;
+        font-size: var(--type-x-small);
+        background-color: var(--color-black);
+        color: var(--color-white);
+        padding: var(--space-x-small) var(--space-small);
+      }
 
-<body>
+      .video-container {
+        display: flex;
+      }
+
+      .video-container .col-1-3 {
+        width: 33.33%;
+      }
+
+      .video-container .col-2-3 {
+        width: 66.66%;
+      }
+
+      .video-container video {
+        width: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
     <div class="layout">
-        <main id="content" class="content">
-            <section class="heavy">
-                <div class="container">
-                    <div class="col-3">
-                        <div class="hero">
-                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
-                            <p class="tagline"><b>Because evolution is <a
-                                        href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
-                                        target="_blank">unitary</a></b>.</p>
-                            <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
-                                <span class="hamburger-box">
-                                    <span class="hamburger-inner"></span>
-                                </span>
-                            </button>
-                        </div>
-                        <p class="subtitle leading-arrow"><a name="research">Research with Unitary Fund</a></p> Unitary Fund believes that research is important for quantum open source. We focus not only on our own research interests, but also building tools to enable others, like those
-                        in our microgrant program. Check out some of the many research projects we've been involved in or supported below!
-                        <p class="subtitle leading-arrow"><a name="research-uf">Unitary Labs research and collaborations</a></p>
-                        The Unitary Fund research <a href="https://github.com/unitaryfund/research">GitHub repo</a> has source code for a selection of our research projects.
-                            <ul style="list-style-type: none;">
-                                <li class="leading-block"><a href="https://dl.acm.org/doi/abs/10.1145/3491101.3519885">Virtual Lab by Quantum Flytrap: Interactive simulation of quantum mechanics</a></li>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2203.05489">Error mitigation increases the effective quantum volume of quantum computers</a>, <a href="https://github.com/unitaryfund/mitiq-qv">source code</a></li>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2009.04417">Mitiq: A software package for error mitigation on noisy quantum computers</a>, <a href="https://mitiq.readthedocs.io/en/latest/examples/mitiq-paper/mitiq-paper-codeblocks.html">source code</a></li>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2005.10921">Digital zero noise extrapolation for quantum error mitigation</a></li>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2108.02237">Extending quantum probabilistic error cancellation by noise scaling</a></li>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2105.09902">Pulse-level noisy quantum circuits with QuTiP</a></li>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2104.15044">Pulser: An open-source package for the design of pulse sequences in programmable neutral-atom arrays</a></li>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2112.05821">VAQEM: A Variational Approach to Quantum Error Mitigation</a></li>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2201.11792">Reducing the impact of time-correlated noise on zero-noise extrapolation
-                                </a></li>
-                            </ul>
-                        <p class="subtitle leading-arrow"><a name="research-staff">Unitary Fund staff research</a></p>
-                            <ul style="list-style-type: none;">
-                                <li class="leading-block"><a href="https://arxiv.org/pdf/2205.04645.pdf">Arkhipov's theorem, graph minors, and linear system nonlocal games</a></li>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2101.05710">Symmetries and conserved quantities of boundary time crystals in generalized spin models</a></li>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2104.09811">Exceptional Point and Cross-Relaxation Effect in a Hybrid Quantum System</a></li>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2008.06517">Estimating the gradient and higher-order derivatives on quantum hardware</a></li>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2201.08175">Diagnosing quantum chaos with out-of-time-ordered-correlator quasiprobability in the kicked-top model
-                                </a></li>
-                            </ul>
-                        <p class="subtitle leading-arrow"><a name="research-microgrant">Microgrant-supported research</a></p>
-                            <ul style="list-style-type: none;">
-                                <li class="leading-block">
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2110.12487">A Programming Language For Quantum Oracle Construction</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2205.02095">qLEET: Visualizing Loss Landscapes, Expressibility, Entangling Power and Training Trajectories for Parameterized Quantum Circuits</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2202.07756">Quantum Games and Interactive Tools for Quantum Technologies Outreach and Education: A Review and Experiences from the Field</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2202.08209">An Extension of Combinatorial Contextuality for Cognitive Protocols</a></li>
-                                    <li class="leading-block"><a href="https://joss.theoj.org/papers/10.21105/joss.03082">toqito -- Theory of quantum information toolkit: A Python package for studying quantum information</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2109.03188">Optimizing Quantum Variational Circuits with Deep Reinforcement Learning</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2107.09805">Loschmidt echo approach to Krylov-subspace approximation error estimation</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2010.03598">K-GRAPE: A Krylov Subspace approach for the efficient control of quantum many-body dynamics</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2007.15671">Optimal Layout Synthesis for Quantum Computing</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2002.09783">Optimality Study of Existing Quantum Computing Layout Synthesis Tools</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2003.06397">QuNetSim: A Software Framework for Quantum Networks</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/1811.04424">Evaluating probabilistic programming languages for simulating quantum correlations</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2003.01695">Robust data encodings for quantum classifiers</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/1904.04735">PyZX: Large Scale Automated Diagrammatic Reasoning</a></li>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/1903.10477">Reducing T-count with the ZX-calculus</a></li>
-                                    <li class="leading-block"><a href="https://quantum-journal.org/papers/q-2020-05-28-272/">Scaling of variational quantum circuit depth for condensed matter systems</a></li>
-                                </li>
-                            </ul>
-                        <footer class="footer leading-arrow light-arrow"> This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
-                                of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request! <br>
-                            <br>
-                            <table>
-                                <tr>
-                                    <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                                class="fa fa-twitter"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                                class="fa fa-twitch"></i></a></th>
-                                    <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                                class="fa fa-youtube"></i></a></th>
-                                    <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                                class="fab fa-discord"></i></a></th>
-                                </tr>
-                            </table> &copy;2020 Unitary Fund
-                        </footer>
-                    </div>
-                    <div class="col-1" id="menu-container">
-                        <table style="width:auto; margin-right:0px; margin-left: auto;">
-                            <tr>
-                                <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                            class="fa fa-twitter"></i></a></th>
-                                <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                            class="fa fa-twitch"></i></a>
-                                </th>
-                                <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                            class="fa fa-youtube"></i></a></th>
-                                <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                            class="fab fa-discord"></i></a>
-                                </th>
-                            </tr>
-                        </table>
-                        <p class="light" id="menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html" class="active">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                    <div id="mobile-menu-container">
-                        <p class="light" id="mobile-menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html" class="active">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                </div>
-            </section>
-        </main>
+      <main id="content" class="content">
+        <section class="heavy">
+          <div class="container">
+            <div class="col-3">
+              <div class="hero">
+                <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
+                <p class="tagline">
+                  <b
+                    >Because evolution is
+                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b
+                  >.
+                </p>
+                <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
+                  <span class="hamburger-box">
+                    <span class="hamburger-inner"></span>
+                  </span>
+                </button>
+              </div>
+              <p class="subtitle leading-arrow">
+                <a name="research">Research with Unitary Fund</a>
+              </p>
+              Unitary Fund believes that research is important for quantum open source. We focus not only on our own
+              research interests, but also building tools to enable others, like those in our microgrant program. Check
+              out some of the many research projects we've been involved in or supported below!
+              <p class="subtitle leading-arrow">
+                <a name="research-uf">Unitary Labs research and collaborations</a>
+              </p>
+              The Unitary Fund research
+              <a href="https://github.com/unitaryfund/research">GitHub repo</a>
+              has source code for a selection of our research projects.
+              <ul style="list-style-type: none">
+                <li class="leading-block">
+                  <a href="https://dl.acm.org/doi/abs/10.1145/3491101.3519885"
+                    >Virtual Lab by Quantum Flytrap: Interactive simulation of quantum mechanics</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2203.05489"
+                    >Error mitigation increases the effective quantum volume of quantum computers</a
+                  >,
+                  <a href="https://github.com/unitaryfund/mitiq-qv">source code</a>
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2009.04417"
+                    >Mitiq: A software package for error mitigation on noisy quantum computers</a
+                  >,
+                  <a href="https://mitiq.readthedocs.io/en/latest/examples/mitiq-paper/mitiq-paper-codeblocks.html"
+                    >source code</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2005.10921"
+                    >Digital zero noise extrapolation for quantum error mitigation</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2108.02237"
+                    >Extending quantum probabilistic error cancellation by noise scaling</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2105.09902">Pulse-level noisy quantum circuits with QuTiP</a>
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2104.15044"
+                    >Pulser: An open-source package for the design of pulse sequences in programmable neutral-atom
+                    arrays</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2112.05821"
+                    >VAQEM: A Variational Approach to Quantum Error Mitigation</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2201.11792"
+                    >Reducing the impact of time-correlated noise on zero-noise extrapolation
+                  </a>
+                </li>
+              </ul>
+              <p class="subtitle leading-arrow">
+                <a name="research-staff">Unitary Fund staff research</a>
+              </p>
+              <ul style="list-style-type: none">
+                <li class="leading-block">
+                  <a href="https://arxiv.org/pdf/2205.04645.pdf"
+                    >Arkhipov's theorem, graph minors, and linear system nonlocal games</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2101.05710"
+                    >Symmetries and conserved quantities of boundary time crystals in generalized spin models</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2104.09811"
+                    >Exceptional Point and Cross-Relaxation Effect in a Hybrid Quantum System</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2008.06517"
+                    >Estimating the gradient and higher-order derivatives on quantum hardware</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2201.08175"
+                    >Diagnosing quantum chaos with out-of-time-ordered-correlator quasiprobability in the kicked-top
+                    model
+                  </a>
+                </li>
+              </ul>
+              <p class="subtitle leading-arrow">
+                <a name="research-microgrant">Microgrant-supported research</a>
+              </p>
+              <ul style="list-style-type: none">
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2110.12487">A Programming Language For Quantum Oracle Construction</a>
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2205.02095"
+                    >qLEET: Visualizing Loss Landscapes, Expressibility, Entangling Power and Training Trajectories for
+                    Parameterized Quantum Circuits</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2202.07756"
+                    >Quantum Games and Interactive Tools for Quantum Technologies Outreach and Education: A Review and
+                    Experiences from the Field</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2202.08209"
+                    >An Extension of Combinatorial Contextuality for Cognitive Protocols</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://joss.theoj.org/papers/10.21105/joss.03082"
+                    >toqito -- Theory of quantum information toolkit: A Python package for studying quantum
+                    information</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2109.03188"
+                    >Optimizing Quantum Variational Circuits with Deep Reinforcement Learning</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2107.09805"
+                    >Loschmidt echo approach to Krylov-subspace approximation error estimation</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2010.03598"
+                    >K-GRAPE: A Krylov Subspace approach for the efficient control of quantum many-body dynamics</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2007.15671">Optimal Layout Synthesis for Quantum Computing</a>
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2002.09783"
+                    >Optimality Study of Existing Quantum Computing Layout Synthesis Tools</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2003.06397">QuNetSim: A Software Framework for Quantum Networks</a>
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/1811.04424"
+                    >Evaluating probabilistic programming languages for simulating quantum correlations</a
+                  >
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/2003.01695">Robust data encodings for quantum classifiers</a>
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/1904.04735">PyZX: Large Scale Automated Diagrammatic Reasoning</a>
+                </li>
+                <li class="leading-block">
+                  <a href="https://arxiv.org/abs/1903.10477">Reducing T-count with the ZX-calculus</a>
+                </li>
+                <li class="leading-block">
+                  <a href="https://quantum-journal.org/papers/q-2020-05-28-272/"
+                    >Scaling of variational quantum circuit depth for condensed matter systems</a
+                  >
+                </li>
+              </ul>
+              <footer class="footer leading-arrow light-arrow">
+                This website is hosted on
+                <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community
+                follows this
+                <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code of conduct</a
+                >. <br />
+                <br />
+                If you have suggestions for changes then please open up a pull request! <br />
+                <br />
+                <table>
+                  <tr>
+                    <th style="text-align: right">
+                      <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"
+                        ><i class="fa fa-youtube"></i
+                      ></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                    </th>
+                  </tr>
+                </table>
+                &copy;2020 Unitary Fund
+              </footer>
+            </div>
+            <div class="col-1" id="menu-container">
+              <table style="width: auto; margin-right: 0px; margin-left: auto">
+                <tr>
+                  <th style="text-align: right">
+                    <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                  </th>
+                </tr>
+              </table>
+              <p class="light" id="menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html" class="active">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+            <div id="mobile-menu-container">
+              <p class="light" id="mobile-menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html" class="active">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
     <script>
-        var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
-        mobileMenuContainer = document.querySelector("#mobile-menu-container");
-        mobileMenuIcon.addEventListener("click", function() {
-            mobileMenuIcon.classList.toggle("is-active");
-            mobileMenuContainer.classList.toggle("active");
-        });
+      var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
+      mobileMenuContainer = document.querySelector("#mobile-menu-container")
+      mobileMenuIcon.addEventListener("click", function () {
+        mobileMenuIcon.classList.toggle("is-active")
+        mobileMenuContainer.classList.toggle("active")
+      })
     </script>
-</body>
-
+  </body>
 </html>

--- a/research.html
+++ b/research.html
@@ -92,46 +92,46 @@
                         <p class="subtitle leading-arrow"><a name="research-uf">Unitary Labs research and collaborations</a></p>
                         The Unitary Fund research <a href="https://github.com/unitaryfund/research">GitHub repo</a> has source code for a selection of our research projects.
                             <ul style="list-style-type: none;">
-                                <li class="leading-block"><a href="https://dl.acm.org/doi/abs/10.1145/3491101.3519885">Virtual Lab by Quantum Flytrap: Interactive simulation of quantum mechanics</a></li><br>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2203.05489">Error mitigation increases the effective quantum volume of quantum computers</a>, <a href="https://github.com/unitaryfund/mitiq-qv">source code</a></li><br>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2009.04417">Mitiq: A software package for error mitigation on noisy quantum computers</a>, <a href="https://mitiq.readthedocs.io/en/latest/examples/mitiq-paper/mitiq-paper-codeblocks.html">source code</a></li><br>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2005.10921">Digital zero noise extrapolation for quantum error mitigation</a></li><br>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2108.02237">Extending quantum probabilistic error cancellation by noise scaling</a></li><br>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2105.09902">Pulse-level noisy quantum circuits with QuTiP</a></li><br>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2104.15044">Pulser: An open-source package for the design of pulse sequences in programmable neutral-atom arrays</a></li><br>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2112.05821">VAQEM: A Variational Approach to Quantum Error Mitigation</a></li><br>
+                                <li class="leading-block"><a href="https://dl.acm.org/doi/abs/10.1145/3491101.3519885">Virtual Lab by Quantum Flytrap: Interactive simulation of quantum mechanics</a></li>
+                                <li class="leading-block"><a href="https://arxiv.org/abs/2203.05489">Error mitigation increases the effective quantum volume of quantum computers</a>, <a href="https://github.com/unitaryfund/mitiq-qv">source code</a></li>
+                                <li class="leading-block"><a href="https://arxiv.org/abs/2009.04417">Mitiq: A software package for error mitigation on noisy quantum computers</a>, <a href="https://mitiq.readthedocs.io/en/latest/examples/mitiq-paper/mitiq-paper-codeblocks.html">source code</a></li>
+                                <li class="leading-block"><a href="https://arxiv.org/abs/2005.10921">Digital zero noise extrapolation for quantum error mitigation</a></li>
+                                <li class="leading-block"><a href="https://arxiv.org/abs/2108.02237">Extending quantum probabilistic error cancellation by noise scaling</a></li>
+                                <li class="leading-block"><a href="https://arxiv.org/abs/2105.09902">Pulse-level noisy quantum circuits with QuTiP</a></li>
+                                <li class="leading-block"><a href="https://arxiv.org/abs/2104.15044">Pulser: An open-source package for the design of pulse sequences in programmable neutral-atom arrays</a></li>
+                                <li class="leading-block"><a href="https://arxiv.org/abs/2112.05821">VAQEM: A Variational Approach to Quantum Error Mitigation</a></li>
                                 <li class="leading-block"><a href="https://arxiv.org/abs/2201.11792">Reducing the impact of time-correlated noise on zero-noise extrapolation
-                                </a></li><br>
+                                </a></li>
                             </ul>
                         <p class="subtitle leading-arrow"><a name="research-staff">Unitary Fund staff research</a></p>
                             <ul style="list-style-type: none;">
-                                <li class="leading-block"><a href="https://arxiv.org/pdf/2205.04645.pdf">Arkhipov's theorem, graph minors, and linear system nonlocal games</a></li><br>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2101.05710">Symmetries and conserved quantities of boundary time crystals in generalized spin models</a></li><br>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2104.09811">Exceptional Point and Cross-Relaxation Effect in a Hybrid Quantum System</a></li><br>
-                                <li class="leading-block"><a href="https://arxiv.org/abs/2008.06517">Estimating the gradient and higher-order derivatives on quantum hardware</a></li><br>
+                                <li class="leading-block"><a href="https://arxiv.org/pdf/2205.04645.pdf">Arkhipov's theorem, graph minors, and linear system nonlocal games</a></li>
+                                <li class="leading-block"><a href="https://arxiv.org/abs/2101.05710">Symmetries and conserved quantities of boundary time crystals in generalized spin models</a></li>
+                                <li class="leading-block"><a href="https://arxiv.org/abs/2104.09811">Exceptional Point and Cross-Relaxation Effect in a Hybrid Quantum System</a></li>
+                                <li class="leading-block"><a href="https://arxiv.org/abs/2008.06517">Estimating the gradient and higher-order derivatives on quantum hardware</a></li>
                                 <li class="leading-block"><a href="https://arxiv.org/abs/2201.08175">Diagnosing quantum chaos with out-of-time-ordered-correlator quasiprobability in the kicked-top model
-                                </a></li><br>
+                                </a></li>
                             </ul>
                         <p class="subtitle leading-arrow"><a name="research-microgrant">Microgrant-supported research</a></p>
                             <ul style="list-style-type: none;">
                                 <li class="leading-block">
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2110.12487">A Programming Language For Quantum Oracle Construction</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2205.02095">qLEET: Visualizing Loss Landscapes, Expressibility, Entangling Power and Training Trajectories for Parameterized Quantum Circuits</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2202.07756">Quantum Games and Interactive Tools for Quantum Technologies Outreach and Education: A Review and Experiences from the Field</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2202.08209">An Extension of Combinatorial Contextuality for Cognitive Protocols</a></li><br>
-                                    <li class="leading-block"><a href="https://joss.theoj.org/papers/10.21105/joss.03082">toqito -- Theory of quantum information toolkit: A Python package for studying quantum information</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2109.03188">Optimizing Quantum Variational Circuits with Deep Reinforcement Learning</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2107.09805">Loschmidt echo approach to Krylov-subspace approximation error estimation</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2010.03598">K-GRAPE: A Krylov Subspace approach for the efficient control of quantum many-body dynamics</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2007.15671">Optimal Layout Synthesis for Quantum Computing</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2002.09783">Optimality Study of Existing Quantum Computing Layout Synthesis Tools</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2003.06397">QuNetSim: A Software Framework for Quantum Networks</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/1811.04424">Evaluating probabilistic programming languages for simulating quantum correlations</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/2003.01695">Robust data encodings for quantum classifiers</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/1904.04735">PyZX: Large Scale Automated Diagrammatic Reasoning</a></li><br>
-                                    <li class="leading-block"><a href="https://arxiv.org/abs/1903.10477">Reducing T-count with the ZX-calculus</a></li><br>
-                                    <li class="leading-block"><a href="https://quantum-journal.org/papers/q-2020-05-28-272/">Scaling of variational quantum circuit depth for condensed matter systems</a></li><br>
-                                </li><br>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/2110.12487">A Programming Language For Quantum Oracle Construction</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/2205.02095">qLEET: Visualizing Loss Landscapes, Expressibility, Entangling Power and Training Trajectories for Parameterized Quantum Circuits</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/2202.07756">Quantum Games and Interactive Tools for Quantum Technologies Outreach and Education: A Review and Experiences from the Field</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/2202.08209">An Extension of Combinatorial Contextuality for Cognitive Protocols</a></li>
+                                    <li class="leading-block"><a href="https://joss.theoj.org/papers/10.21105/joss.03082">toqito -- Theory of quantum information toolkit: A Python package for studying quantum information</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/2109.03188">Optimizing Quantum Variational Circuits with Deep Reinforcement Learning</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/2107.09805">Loschmidt echo approach to Krylov-subspace approximation error estimation</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/2010.03598">K-GRAPE: A Krylov Subspace approach for the efficient control of quantum many-body dynamics</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/2007.15671">Optimal Layout Synthesis for Quantum Computing</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/2002.09783">Optimality Study of Existing Quantum Computing Layout Synthesis Tools</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/2003.06397">QuNetSim: A Software Framework for Quantum Networks</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/1811.04424">Evaluating probabilistic programming languages for simulating quantum correlations</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/2003.01695">Robust data encodings for quantum classifiers</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/1904.04735">PyZX: Large Scale Automated Diagrammatic Reasoning</a></li>
+                                    <li class="leading-block"><a href="https://arxiv.org/abs/1903.10477">Reducing T-count with the ZX-calculus</a></li>
+                                    <li class="leading-block"><a href="https://quantum-journal.org/papers/q-2020-05-28-272/">Scaling of variational quantum circuit depth for condensed matter systems</a></li>
+                                </li>
                             </ul>
                         <footer class="footer leading-arrow light-arrow"> This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
                                 of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request! <br>

--- a/research.html
+++ b/research.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html>
-<script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -27,6 +26,7 @@
             margin: 10px;
         }
     </style>
+    <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>

--- a/research.html
+++ b/research.html
@@ -88,15 +88,11 @@
                   </span>
                 </button>
               </div>
-              <p class="subtitle leading-arrow">
-                <a name="research">Research with Unitary Fund</a>
-              </p>
+              <p class="subtitle leading-arrow">Research with Unitary Fund</p>
               Unitary Fund believes that research is important for quantum open source. We focus not only on our own
               research interests, but also building tools to enable others, like those in our microgrant program. Check
               out some of the many research projects we've been involved in or supported below!
-              <p class="subtitle leading-arrow">
-                <a name="research-uf">Unitary Labs research and collaborations</a>
-              </p>
+              <p class="subtitle leading-arrow">Unitary Labs research and collaborations</p>
               The Unitary Fund research
               <a href="https://github.com/unitaryfund/research">GitHub repo</a>
               has source code for a selection of our research projects.
@@ -150,9 +146,7 @@
                   </a>
                 </li>
               </ul>
-              <p class="subtitle leading-arrow">
-                <a name="research-staff">Unitary Fund staff research</a>
-              </p>
+              <p class="subtitle leading-arrow">Unitary Fund staff research</p>
               <ul style="list-style-type: none">
                 <li class="leading-block">
                   <a href="https://arxiv.org/pdf/2205.04645.pdf"
@@ -181,9 +175,7 @@
                   </a>
                 </li>
               </ul>
-              <p class="subtitle leading-arrow">
-                <a name="research-microgrant">Microgrant-supported research</a>
-              </p>
+              <p class="subtitle leading-arrow">Microgrant-supported research</p>
               <ul style="list-style-type: none">
                 <li class="leading-block">
                   <a href="https://arxiv.org/abs/2110.12487">A Programming Language For Quantum Oracle Construction</a>

--- a/research.html
+++ b/research.html
@@ -91,7 +91,6 @@
                         in our microgrant program. Check out some of the many research projects we've been involved in or supported below!
                         <p class="subtitle leading-arrow"><a name="research-uf">Unitary Labs research and collaborations</a></p>
                         The Unitary Fund research <a href="https://github.com/unitaryfund/research">GitHub repo</a> has source code for a selection of our research projects.
-                        <p>
                             <ul style="list-style-type: none;">
                                 <li class="leading-block"><a href="https://dl.acm.org/doi/abs/10.1145/3491101.3519885">Virtual Lab by Quantum Flytrap: Interactive simulation of quantum mechanics</a></li><br>
                                 <li class="leading-block"><a href="https://arxiv.org/abs/2203.05489">Error mitigation increases the effective quantum volume of quantum computers</a>, <a href="https://github.com/unitaryfund/mitiq-qv">source code</a></li><br>
@@ -104,9 +103,7 @@
                                 <li class="leading-block"><a href="https://arxiv.org/abs/2201.11792">Reducing the impact of time-correlated noise on zero-noise extrapolation
                                 </a></li><br>
                             </ul>
-                        </p>
                         <p class="subtitle leading-arrow"><a name="research-staff">Unitary Fund staff research</a></p>
-                        <p>
                             <ul style="list-style-type: none;">
                                 <li class="leading-block"><a href="https://arxiv.org/pdf/2205.04645.pdf">Arkhipov's theorem, graph minors, and linear system nonlocal games</a></li><br>
                                 <li class="leading-block"><a href="https://arxiv.org/abs/2101.05710">Symmetries and conserved quantities of boundary time crystals in generalized spin models</a></li><br>
@@ -115,9 +112,7 @@
                                 <li class="leading-block"><a href="https://arxiv.org/abs/2201.08175">Diagnosing quantum chaos with out-of-time-ordered-correlator quasiprobability in the kicked-top model
                                 </a></li><br>
                             </ul>
-                        </p>
                         <p class="subtitle leading-arrow"><a name="research-microgrant">Microgrant-supported research</a></p>
-                        <p>
                             <ul style="list-style-type: none;">
                                 <li class="leading-block">
                                     <li class="leading-block"><a href="https://arxiv.org/abs/2110.12487">A Programming Language For Quantum Oracle Construction</a></li><br>
@@ -138,7 +133,6 @@
                                     <li class="leading-block"><a href="https://quantum-journal.org/papers/q-2020-05-28-272/">Scaling of variational quantum circuit depth for condensed matter systems</a></li><br>
                                 </li><br>
                             </ul>
-                        </p>
                         <footer class="footer leading-arrow light-arrow"> This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community follows this <a href="https://github.com/unitaryfund/unitary-fund/blob/master/CODE_OF_CONDUCT.md">code
                                 of conduct</a>. <br> <br> If you have suggestions for changes then please open up a pull request! <br>
                             <br>

--- a/research.html
+++ b/research.html
@@ -77,7 +77,7 @@
                 <div class="container">
                     <div class="col-3">
                         <div class="hero">
-                            <a href="/"><img src="/logos/logov3.svg" alt="Unitary Fund" /></a>
+                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
                             <p class="tagline"><b>Because evolution is <a
                                         href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
                                         target="_blank">unitary</a></b>.</p>

--- a/style.css
+++ b/style.css
@@ -68,6 +68,11 @@ h1 {
     font-family: var(--font-mono);
 }
 
+h4.grant-year {
+    margin-top: 50px;
+    margin-bottom: 50px;
+}
+
 .tagline {
     font-family: var(--font-mono);
     font-size: var(--type-small);
@@ -85,6 +90,10 @@ a:visited {
 
 a:hover {
     background-color: var(--color-yellow);
+}
+
+li:not(:last-child) {
+    margin-bottom: 25px;
 }
 
 .layout {
@@ -308,28 +317,28 @@ img {
     background-color: var(--color-black);
 }
 
-#grant-list {
+.grant-list {
     list-style-type: none;
     padding: 0;
 }
 
-#grant-list li {
+.grant-list li {
     list-style-type: none;
     display: flex;
     flex-direction: row;
     align-items: flex-start;
 }
 
-#grant-list li a.recipient-link {
+.grant-list li a.recipient-link {
     font-weight: bold;
 }
 
-#grant-list li img.grant-image {
+.grant-list li img.grant-image {
     border: 3px solid black;
     border-left: none;
 }
 
-#grant-list li p {
+.grant-list li p {
     margin: 0;
     margin-left: var(--space-base);
 }

--- a/talks.html
+++ b/talks.html
@@ -53,7 +53,7 @@
                 <div class="container">
                     <div class="col-3">
                         <div class="hero">
-                            <a href="/"><img src="/logos/logov3.svg" alt="Unitary Fund" /></a>
+                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
                             <p class="tagline"><b>Because evolution is
                                 <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
                                 target="_blank">unitary</a></b>.</p>

--- a/talks.html
+++ b/talks.html
@@ -87,7 +87,7 @@
                             want to chat with the speakers or the community more generally, check out the <a href="https://discord.gg/JqVGmpkP96">Unitary Fund Discord</a>.
 
                             <p>
-                                If you work on a open source quantum software and have a project you would like to speak about, please <a href="mailto: contribute@unitary.fund">drop us a line!</a>
+                                If you work on a open source quantum software and have a project you would like to speak about, please <a href="mailto:contribute@unitary.fund">drop us a line!</a>
                             </p>
 
                             <p class="subtitle leading-arrow">Upcoming talks</p>

--- a/talks.html
+++ b/talks.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 
 <html>
-<script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
-<script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
 
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -33,6 +31,7 @@
         }
     </style>
 
+    <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>

--- a/talks.html
+++ b/talks.html
@@ -65,9 +65,7 @@
                   </span>
                 </button>
               </div>
-              <p class="subtitle leading-arrow">
-                <a name="calendar">Unitary Fund Community Calendar</a>
-              </p>
+              <p class="subtitle leading-arrow">Unitary Fund Community Calendar</p>
               <p>
                 Want to keep up to date with all the cool stuff the Unitary Fund community is up to? Take a look at the
                 calendar below and add it to your favorite calendar app!
@@ -106,9 +104,7 @@
               </script>
 
               <p></p>
-              <p class="subtitle leading-arrow">
-                <a name="talks">Quantum Software Talks</a>
-              </p>
+              <p class="subtitle leading-arrow">Quantum Software Talks</p>
               The Unitary Fund is pleased to host a online talk series that features open source quantum software
               projects. All seminars will be hosted at
               <a href="https://www.twitch.tv/unitaryfund">twitch.tv/unitaryfund</a>, and if you want to chat with the

--- a/talks.html
+++ b/talks.html
@@ -1,365 +1,584 @@
 <!DOCTYPE html>
 
 <html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
 
     <title>Unitary Fund</title>
     <!-- CSS -->
-    <link rel="stylesheet" type="text/css" href="style.css">
-    <link rel="stylesheet" type="text/css" href="hamburgers.min.css">
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
-    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+    <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
-        #mc_embed_signup {
-            background: #fff;
-            clear: left;
-            font: 14px "Lucida Console", Monaco, monospace;
-            width: 100%;
-        }
-        
-        #mce-EMAIL {
-            padding: 11px;
-            margin: 10px;
-        }
+      #mc_embed_signup {
+        background: #fff;
+        clear: left;
+        font: 14px "Lucida Console", Monaco, monospace;
+        width: 100%;
+      }
+
+      #mce-EMAIL {
+        padding: 11px;
+        margin: 10px;
+      }
     </style>
 
     <script src="https://kit.fontawesome.com/22ffc91bdd.js" crossorigin="anonymous"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19932157-4"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
+      window.dataLayer = window.dataLayer || []
 
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-        gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-        gtag('config', 'UA-19932157-4');
+      gtag("config", "UA-19932157-4")
     </script>
-</head>
+  </head>
 
-<body>
+  <body>
     <div class="layout">
-        <main id="content" class="content">
-            <section class="heavy">
-                <div class="container">
-                    <div class="col-3">
-                        <div class="hero">
-                            <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
-                            <p class="tagline"><b>Because evolution is
-                                <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)"
-                                target="_blank">unitary</a></b>.</p>
-                            <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
-                                    <span class="hamburger-box">
-                                        <span class="hamburger-inner"></span>
-                                    </span>
-                                </button>
-                        </div>
-                        <p class="subtitle leading-arrow"><a name="calendar">Unitary Fund Community Calendar</a></p>
-                            <p>
-                                Want to keep up to date with all the cool stuff the Unitary Fund community is up to? Take a look at the calendar below and add it to your favorite calendar app!</p>
-                            <div class="ae-emd-cal" data-calendar="kn360162" data-calendars="kn360162" data-calendars-selected="kn360162" data-configure="true" data-title="" data-title-show="true" data-today="true" data-datenav="true" data-date="true" data-monthweektoggle="true"
-                                data-subscribebtn="true" data-swimonth="true" data-swiweek="true" data-swischedule="true" data-print="false" data-timezone="true" data-logo="false" data-defaultview="schedule" data-firstday="0" data-datetimeformat="2"></div>
-                            <script type="text/javascript">
-                                (function() {
-                                    var e = document.createElement("script");
-                                    e.type = "text/javascript";
-                                    e.async = true;
-                                    e.src = "https://cdn.addevent.com/libs/cal/js/cal.embed.t1.init.js";
-                                    e.className = "ae-emd-script";
-                                    document.getElementsByTagName("body")[0].appendChild(e);
-                                })();
-                            </script>
+      <main id="content" class="content">
+        <section class="heavy">
+          <div class="container">
+            <div class="col-3">
+              <div class="hero">
+                <a href="/"><img src="logos/logov3.svg" alt="Unitary Fund" /></a>
+                <p class="tagline">
+                  <b
+                    >Because evolution is
+                    <a href="https://en.wikipedia.org/wiki/Unitarity_(physics)" target="_blank">unitary</a></b
+                  >.
+                </p>
+                <button id="mobile-menu-icon" class="hamburger hamburger--squeeze" type="button">
+                  <span class="hamburger-box">
+                    <span class="hamburger-inner"></span>
+                  </span>
+                </button>
+              </div>
+              <p class="subtitle leading-arrow">
+                <a name="calendar">Unitary Fund Community Calendar</a>
+              </p>
+              <p>
+                Want to keep up to date with all the cool stuff the Unitary Fund community is up to? Take a look at the
+                calendar below and add it to your favorite calendar app!
+              </p>
+              <div
+                class="ae-emd-cal"
+                data-calendar="kn360162"
+                data-calendars="kn360162"
+                data-calendars-selected="kn360162"
+                data-configure="true"
+                data-title=""
+                data-title-show="true"
+                data-today="true"
+                data-datenav="true"
+                data-date="true"
+                data-monthweektoggle="true"
+                data-subscribebtn="true"
+                data-swimonth="true"
+                data-swiweek="true"
+                data-swischedule="true"
+                data-print="false"
+                data-timezone="true"
+                data-logo="false"
+                data-defaultview="schedule"
+                data-firstday="0"
+                data-datetimeformat="2"></div>
+              <script type="text/javascript">
+                ;(function () {
+                  var e = document.createElement("script")
+                  e.type = "text/javascript"
+                  e.async = true
+                  e.src = "https://cdn.addevent.com/libs/cal/js/cal.embed.t1.init.js"
+                  e.className = "ae-emd-script"
+                  document.getElementsByTagName("body")[0].appendChild(e)
+                })()
+              </script>
 
-                        <p>
-                            <p class="subtitle leading-arrow"><a name="talks">Quantum Software Talks</a></p>
-                            The Unitary Fund is pleased to host a online talk series that features open source quantum software projects. All seminars will be hosted at <a href="https://www.twitch.tv/unitaryfund">twitch.tv/unitaryfund</a>, and if you
-                            want to chat with the speakers or the community more generally, check out the <a href="https://discord.gg/JqVGmpkP96">Unitary Fund Discord</a>.
+              <p></p>
+              <p class="subtitle leading-arrow">
+                <a name="talks">Quantum Software Talks</a>
+              </p>
+              The Unitary Fund is pleased to host a online talk series that features open source quantum software
+              projects. All seminars will be hosted at
+              <a href="https://www.twitch.tv/unitaryfund">twitch.tv/unitaryfund</a>, and if you want to chat with the
+              speakers or the community more generally, check out the
+              <a href="https://discord.gg/JqVGmpkP96">Unitary Fund Discord</a>.
 
-                            <p>
-                                If you work on a open source quantum software and have a project you would like to speak about, please <a href="mailto:contribute@unitary.fund">drop us a line!</a>
-                            </p>
+              <p>
+                If you work on a open source quantum software and have a project you would like to speak about, please
+                <a href="mailto:contribute@unitary.fund">drop us a line!</a>
+              </p>
 
-                            <p class="subtitle leading-arrow">Upcoming talks</p>
-                            <ul style="list-style-type: none;">
+              <p class="subtitle leading-arrow">Upcoming talks</p>
+              <ul style="list-style-type: none"></ul>
 
-                            </ul>
+              <p class="subtitle leading-arrow">Previous talks</p>
+              <ul style="list-style-type: none">
+                <li class="leading-block">
+                  <span class="blog-post-date"
+                    >7 April, 2022 - 12pm EST/5pm GMT
+                    <!-- <a title="Add to Calendar" class="addeventatc" data-id="jg13211859" href="https://www.addevent.com/event/jg13211859" target="_blank" rel="nofollow">Add to Calendar</a> -->
+                    <script
+                      type="text/javascript"
+                      src="https://cdn.addevent.com/libs/atc/1.6.1/atc.min.js"
+                      async
+                      defer></script
+                  ></span>
+                  <h4>
+                    <a href="https://qutip.org/docs/latest/guide/guide-qip.html">qutip-qip</a>: Pulse-level circuits
+                    simulation by Boxi Li
+                  </h4>
+                  <iframe
+                    class="video"
+                    src="https://www.youtube-nocookie.com/embed/-q5a38Pw7Rg"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+                  <details>
+                    <summary>About the talk</summary>
+                    <p>
+                      In quantum computing, a quantum circuit is often represented as a sequence of unitary gates.
+                      However, when engineering quantum hardware, the physical qubits and their dynamics are usually
+                      described by the Hamiltonians. The characterization of noise also varies in those two different
+                      representations. Boxi will talk about quantum circuits represented by the control Hamiltonians and
+                      introduce the qutip-qip package, which represents and simulates quantum circuits at the pulse
+                      level. As a family package under the QuTiP organization, it leverages QuTiP's quantum dynamics
+                      solvers to solve the continuous time evolution of the qubits with realistic physical models. The
+                      package includes a few predefined physical models and provides the necessary compiling and
+                      scheduling functionality. In addition, it allows the user to build custom models of physical
+                      qubits and define various types of noise, such as environment-induced decoherence and noise in the
+                      control pulses.
+                    </p>
+                  </details>
+                  <br />
+                  <details>
+                    <summary>About the speaker</summary>
+                    <p>
+                      <strong>Boxi Li</strong> is a PhD candidate at Forschungszentrum Jülich (Jülich research centre)
+                      in Germany, working on quantum control and modelling for superconducting qubits. I did my
+                      Bachelors at the University of Heidelberg and went to ETHZ for a master's degree, during which I
+                      also enjoyed a short stay at TU Delft, exploring the magic of quantum networks. I started my
+                      contribution to QuTiP from a GSoC project in 2019 and joined the development team thereafter,
+                      mainly maintaining the qutip-qip repository.
+                    </p>
+                  </details>
+                  <br />
+                </li>
+                <li class="leading-block">
+                  <span class="blog-post-date">23 November, 2021 - 12pm EST/5pm GMT</span>
+                  <h4>
+                    <a href="https://github.com/pedrorrivero/qrand">qrand</a>: A multi-platform and multi-protocol
+                    quantum random number generator for arbitrary probability distributions by Pedro Rivero
+                  </h4>
+                  <iframe
+                    class="video"
+                    src="https://www.youtube-nocookie.com/embed/srZddqGdVNE"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+                  <details>
+                    <summary>About the talk</summary>
+                    <p>
+                      Random numbers are everywhere. Computer algorithms, data encryption, physical simulations, and
+                      even the arts use them all the time. There is one problem though: it turns out that they are
+                      actually very difficult to produce in large amounts. Luckily, the probabilistic nature of quantum
+                      computers makes these devices particularly useful for the task. QRAND introduces a versatile
+                      interface layer between NumPy and several quantum computing platforms (qiskit, cirq, qsharp...),
+                      along with some useful functionality that enables the production of quantum random numbers (QRN)
+                      according to different quantum protocols, and for a wide variety of probability distributions.
+                    </p>
+                  </details>
+                  <br />
+                  <details>
+                    <summary>About the speaker</summary>
+                    <p>
+                      <strong>Pedro Rivero</strong> is an algorithm and quantum software developer at Argonne National
+                      Laboratory and is enrolled in a a PhD course at the Illinois Institute of Technology.
+                    </p>
+                  </details>
+                </li>
+                <li class="leading-block">
+                  <span class="blog-post-date">11 November, 2021 - 11:30 PST/19:30 GMT</span>
+                  <h4>
+                    <a href="http://www.pygsti.info/">pyGSTi</a>: A toolkit for quantum characterization by Erik Nielsen
+                    and Kenneth Rudinger
+                  </h4>
+                  <iframe
+                    class="video"
+                    src="https://www.youtube-nocookie.com/embed/45YXL49MSx4"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+                  <p>
+                    <a href="https://zenodo.org/record/5715199"> Sample Jupyter notebooks from the talk</a>
+                  </p>
+                  <details>
+                    <summary>About the talk</summary>
+                    <p>
+                      In this talk, we will present pyGSTi, a python package for generating and analyzing quantum
+                      characterization, verification, and validation experiments, with particular focus on gate set
+                      tomography and scalable forms of randomized benchmarking. pyGSTi has been used to characterize and
+                      improve quantum hardware performance across a wide variety of platforms, including trapped ion,
+                      superconducting transmon, and silicon spin qubit devices. We will discuss the motivation behind
+                      pyGSTi, explore the functionality of and interplay between its basic objects, and provide several
+                      demonstrations of the code in action. These demonstrations will span a variety of examples, from
+                      high-level analyses which require minimal pyGSTi knowledge to more complex use cases which can
+                      fully leverage pyGSTi’s broad capabilities.
+                    </p>
+                  </details>
+                  <br />
+                  <details>
+                    <summary>About the speaker</summary>
+                    <p>
+                      Erik and Kenneth both are researchers and developers working on pyGSTi at Sandia National Labs.
+                    </p>
+                  </details>
+                </li>
+                <li class="leading-block">
+                  <span class="blog-post-date">19 August, 2021 - 12pm EST/5pm GMT</span>
+                  <h4>
+                    Intro to
+                    <a href="https://github.com/xvzcf/VeriFrodo">VeriFrodo</a>: The post-quantum cryptographic software
+                    ecosystem by Goutam Tamvada
+                  </h4>
+                  <iframe
+                    class="video"
+                    src="https://www.youtube-nocookie.com/embed/rVMcplTyPpg"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+                  <details>
+                    <summary>About the talk</summary>
+                    <p>
+                      Verifrodo is an open-source package implementing a lattice-based quantum-resistant cryptographic
+                      algorithms in Jasmin within the Open Quantum Safe project. This talk will provide an overview of
+                      post-quantum cryptography and its use in internet protocols and software applications, as well as
+                      place our Unitary Fund project, VeriFrodo, in this context.
+                    </p>
+                  </details>
+                  <br />
+                  <details>
+                    <summary>About the speaker</summary>
+                    <p>
+                      <strong>Goutam Tamvada</strong> has a Bachelor of Applied Science in Computer Engineering from the
+                      University of Waterloo, and has been working on open source software for the Open Quantum Safe
+                      project for the past 2 years.
+                    </p>
+                  </details>
+                </li>
 
-                            <p class="subtitle leading-arrow">Previous talks</p>
-                            <ul style="list-style-type: none;">
-                                <li class="leading-block"><span class="blog-post-date">7 April, 2022 - 12pm EST/5pm GMT 
-                                    <!-- <a title="Add to Calendar" class="addeventatc" data-id="jg13211859" href="https://www.addevent.com/event/jg13211859" target="_blank" rel="nofollow">Add to Calendar</a> -->
-                                    <script type="text/javascript" src="https://cdn.addevent.com/libs/atc/1.6.1/atc.min.js" async defer></script></span>
-                                    <h4><a href="https://qutip.org/docs/latest/guide/guide-qip.html">qutip-qip</a>: Pulse-level circuits simulation by Boxi Li</h4>
-                                    <iframe class="video" src="https://www.youtube-nocookie.com/embed/-q5a38Pw7Rg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                                    <details>
-                                        <summary>About the talk</summary>
-                                        <p> In quantum computing, a quantum circuit is often represented as a sequence of unitary gates. However, when engineering quantum hardware, the physical qubits and their dynamics are usually described by the Hamiltonians.
-                                            The characterization of noise also varies in those two different representations. Boxi will talk about quantum circuits represented by the control Hamiltonians and introduce the qutip-qip package, which represents
-                                            and simulates quantum circuits at the pulse level. As a family package under the QuTiP organization, it leverages QuTiP's quantum dynamics solvers to solve the continuous time evolution of the qubits with realistic
-                                            physical models. The package includes a few predefined physical models and provides the necessary compiling and scheduling functionality. In addition, it allows the user to build custom models of physical qubits
-                                            and define various types of noise, such as environment-induced decoherence and noise in the control pulses.</p>
-                                    </details>
-                                    <br>
-                                    <details>
-                                        <summary>About the speaker</summary>
-                                        <p><strong>Boxi Li</strong> is a PhD candidate at Forschungszentrum Jülich (Jülich research centre) in Germany, working on quantum control and modelling for superconducting qubits. I did my Bachelors at the University
-                                            of Heidelberg and went to ETHZ for a master's degree, during which I also enjoyed a short stay at TU Delft, exploring the magic of quantum networks. I started my contribution to QuTiP from a GSoC project in
-                                            2019 and joined the development team thereafter, mainly maintaining the qutip-qip repository.
-                                        </p>
-                                    </details>
-                                    <br>
+                <li class="leading-block">
+                  <span class="blog-post-date">20 May, 2021 - 12pm EST/5pm GMT</span>
+                  <h4>
+                    Intro to
+                    <a href="https://github.com/pasqal-io/Pulser">Pulser</a>: Pulse simulation and design for neutral
+                    atoms by Loïc Henriet
+                  </h4>
+                  <iframe
+                    class="video"
+                    src="https://www.youtube-nocookie.com/embed/Y4aM9G21tXk"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+                  <br />
+                  <details>
+                    <summary>About the talk</summary>
+                    <p>
+                      The manipulation of neutral atoms by light is at the heart of countless scientific discoveries in
+                      the field of quantum physics in the last three decades. The level of control that has been
+                      achieved at the single particle level within arrays of optical traps, while preserving the
+                      fundamental properties of quantum matter (coherence, entanglement, superposition), makes these
+                      technologies prime candidates to implement disruptive computation paradigms. In this talk, I will
+                      present
+                      <a href="https://github.com/pasqal-io/Pulser">pulser</a>, a recently developed open-source python
+                      framework enabling practitioners to control those devices at the pulse level.
+                    </p>
+                  </details>
+                  <br />
+                  <details>
+                    <summary>About the speaker</summary>
+                    <p>
+                      <strong>Loïc Henriet</strong> holds an engineering degree and a PhD in theoretical physics from
+                      Ecole Polytechnique, in France. He subsequently worked as a researcher at the Institute for
+                      Photonic Sciences (ICFO) in Barcelona, Spain. His research interests lied in the description of
+                      collective effects in light-matter systems. In June 2019, he joined Pasqal, a Paris-based quantum
+                      computing startup manufacturing quantum processors powered by arrays of single atoms. Since then,
+                      he has been heading the quantum software developments.
+                    </p>
+                  </details>
+                </li>
 
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">23 November, 2021 - 12pm EST/5pm GMT</span>
-                                    <h4><a href="https://github.com/pedrorrivero/qrand">qrand</a>: A multi-platform and multi-protocol quantum random number generator for arbitrary probability distributions by Pedro Rivero</h4>
-                                    <iframe class="video" src="https://www.youtube-nocookie.com/embed/srZddqGdVNE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                                    <details>
-                                        <summary>About the talk</summary>
-                                        <p> Random numbers are everywhere. Computer algorithms, data encryption, physical simulations, and even the arts use them all the time. There is one problem though: it turns out that they are actually very difficult
-                                            to produce in large amounts. Luckily, the probabilistic nature of quantum computers makes these devices particularly useful for the task. QRAND introduces a versatile interface layer between NumPy and several
-                                            quantum computing platforms (qiskit, cirq, qsharp...), along with some useful functionality that enables the production of quantum random numbers (QRN) according to different quantum protocols, and for a wide
-                                            variety of probability distributions.</p>
-                                    </details>
-                                    <br>
-                                    <details>
-                                        <summary>About the speaker</summary>
-                                        <p><strong>Pedro Rivero</strong> is an algorithm and quantum software developer at Argonne National Laboratory and is enrolled in a a PhD course at the Illinois Institute of Technology.
-                                        </p>
-                                    </details>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">11 November, 2021 - 11:30 PST/19:30 GMT</span>
-                                    <h4><a href="http://www.pygsti.info/">pyGSTi</a>: A toolkit for quantum characterization by Erik Nielsen and Kenneth Rudinger</h4>
-                                    <iframe class="video" src="https://www.youtube-nocookie.com/embed/45YXL49MSx4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                                    <p><a href="https://zenodo.org/record/5715199"> Sample Jupyter notebooks from the talk</a></p>
-                                    <details>
-                                        <summary>About the talk</summary>
-                                        <p> In this talk, we will present pyGSTi, a python package for generating and analyzing quantum characterization, verification, and validation experiments, with particular focus on gate set tomography and scalable forms
-                                            of randomized benchmarking. pyGSTi has been used to characterize and improve quantum hardware performance across a wide variety of platforms, including trapped ion, superconducting transmon, and silicon spin
-                                            qubit devices. We will discuss the motivation behind pyGSTi, explore the functionality of and interplay between its basic objects, and provide several demonstrations of the code in action. These demonstrations
-                                            will span a variety of examples, from high-level analyses which require minimal pyGSTi knowledge to more complex use cases which can fully leverage pyGSTi’s broad capabilities.</p>
-                                    </details>
-                                    <br>
-                                    <details>
-                                        <summary>About the speaker</summary>
-                                        <p>Erik and Kenneth both are researchers and developers working on pyGSTi at Sandia National Labs.
-                                        </p>
-                                    </details>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">19 August, 2021 - 12pm EST/5pm
-                                GMT</span>
-                                    <h4>Intro to <a href="https://github.com/xvzcf/VeriFrodo">VeriFrodo</a>: The post-quantum cryptographic software ecosystem by Goutam Tamvada</h4>
-                                    <iframe class="video" src="https://www.youtube-nocookie.com/embed/rVMcplTyPpg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                                    <details>
-                                        <summary>About the talk</summary>
-                                        <p> Verifrodo is an open-source package implementing a lattice-based quantum-resistant cryptographic algorithms in Jasmin within the Open Quantum Safe project. This talk will provide an overview of post-quantum cryptography
-                                            and its use in internet protocols and software applications, as well as place our Unitary Fund project, VeriFrodo, in this context.</p>
-                                    </details>
-                                    <br>
-                                    <details>
-                                        <summary>About the speaker</summary>
-                                        <p><strong>Goutam Tamvada</strong> has a Bachelor of Applied Science in Computer Engineering from the University of Waterloo, and has been working on open source software for the Open Quantum Safe project for the past
-                                            2 years.
-                                        </p>
-                                    </details>
-                                </li>
+                <li class="leading-block">
+                  <span class="blog-post-date">18 March, 2021 - 12pm EST/5pm GMT</span>
+                  <h4>
+                    Intro to
+                    <a href="http://github.com/tqsd/QuNetSim">QuNetSim</a>: A Software Framework for Quantum Networks by
+                    Stephen DiAdamo
+                  </h4>
+                  <iframe
+                    class="video"
+                    src="https://www.youtube-nocookie.com/embed/MmdRLYh1_mI"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+                  <br />
+                  <br />
+                  <details>
+                    <summary>About the talk</summary>
+                    <p>
+                      <a href="http://github.com/tqsd/QuNetSim">QuNetSim</a> is a quantum-enabled network simulator that
+                      adds common quantum networking tasks like teleportation, superdense coding, sharing EPR pairs,
+                      etc, to aid in the develop of quantum networking protocols. With QuNetSim, one can design and test
+                      robust quantum network protocols under various network conditions. In this presentation I will
+                      give an overview of what QuNetSim does and demonstrate some examples of how it can be used.
+                    </p>
+                  </details>
+                  <br />
+                  <details>
+                    <summary>About the speaker</summary>
+                    <p>
+                      <strong>Stephen DiAdamo</strong> is an electrical engineering PhD student from TU Munich. After
+                      completing his bachelor's in computer science from the University of Toronto, he moved to Munich,
+                      Germany to complete a mathematics master's degree at TU Munich and continued after as a PhD
+                      student. His research involves applications of entanglement in quantum networks as well as quantum
+                      simulation development.
+                    </p>
+                  </details>
+                </li>
 
+                <li class="leading-block">
+                  <span class="blog-post-date">28 January, 2021 - 12pm EST/5pm GMT</span>
+                  <h4>
+                    Intro to <a href="http://qutip.org/">QuTiP</a>: A Quantum Toolbox in Python by Shahnawaz Ahmed
+                  </h4>
+                  <iframe
+                    class="video"
+                    src="https://www.youtube-nocookie.com/embed/2tF_4ZJAuYY"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+                  <br />
+                  <br />
+                  <details>
+                    <summary>About the talk</summary>
+                    <p>
+                      <a href="http://qutip.org/">QuTiP</a>: A quantum toolbox in Python, is one of the most popular
+                      tools to simulate open quantum systems – but it has expanded beyond that over the years. It is a
+                      simple but powerful library that, used by students, researchers, engineers, is having a tremendous
+                      impact on quantum science research. QuTiP is also Unitary Fund’s first affiliated project. In this
+                      talk, I will introduce the library and take the example of some new developments in QuTiP to show
+                      the ease with which one can simulate open quantum systems as well as contribute to the development
+                      of such open-source software tools to promote reproducibility and therefore accelerate the
+                      adoption of a particular simulation technique across the research community.
+                    </p>
+                  </details>
+                  <br />
+                  <details>
+                    <summary>About the speaker</summary>
+                    <p>
+                      <strong>Shahnawaz Ahmed</strong> is a graduate student at the Wallenberg Center for Quantum
+                      Technology at Chalmers University, Sweden. His research interest lies in the intersection of
+                      machine learning and quantum computing. He also works on numerical approaches to solve problems in
+                      open quantum systems and is a member of the QuTiP development team.
+                    </p>
+                  </details>
+                </li>
+              </ul>
+              <ul style="list-style-type: none">
+                <li class="leading-block">
+                  <span class="blog-post-date">03 December, 2020 - 12pm EST/5pm GMT</span>
+                  <h4>
+                    Intro to <a href="https://qcor.ornl.gov/">qcor</a>: Extending C++ for Heterogeneous
+                    Quantum-Classical Computing by Alex McCaskey
+                  </h4>
+                  <iframe
+                    class="video"
+                    src="https://www.youtube-nocookie.com/embed/GzslhEnHUHI"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+                  <br />
+                  <br />
+                  <details>
+                    <summary>About the talk</summary>
+                    <p>
+                      We present
+                      <strong><a href="https://qcor.ornl.gov/">qcor</a></strong>
+                      - a language extension to C++ and compiler implementation that enables heterogeneous
+                      quantum-classical programming, compilation, and execution in a single-source context. Our work
+                      provides a first-of-its-kind C++ compiler enabling high-level quantum kernel (function) expression
+                      in a quantum-language agnostic manner, as well as a hardware-agnostic, retargetable compiler
+                      workflow targeting a number of physical and virtual quantum computing backends. qcor leverages
+                      novel Clang plugin interfaces and builds upon the
+                      <a href="https://github.com/eclipse/xacc"> XACC</a>
+                      system-level quantum programming framework to provide a state-of-the-art integration mechanism for
+                      quantum-classical compilation that leverages the best from the community at-large. qcor translates
+                      quantum kernels ultimately to the XACC intermediate representation, and provides user-extensible
+                      hooks for quantum compilation routines like circuit optimization, analysis, and placement. This
+                      work details the overall architecture and compiler workflow for qcor, and provides a number of
+                      illuminating programming examples demonstrating its utility for near-term variational tasks,
+                      quantum algorithm expression, and feed-forward error correction schemes.
+                    </p>
+                  </details>
+                  <br />
+                  <details>
+                    <summary>About the speaker</summary>
+                    <p>
+                      <strong>Alex McCaskey</strong> is a research scientist in the Computer Science and Mathematics
+                      Division at Oak Ridge National Laboratory. He serves as the Software Lead for the Quantum
+                      Computing Institute at ORNL and is the Project Lead for the XACC quantum framework and the QCOR
+                      quantum-classical C++ compiler. He received his Masters in Physics from Virginia Tech and BS
+                      degrees in Physics and Mathematics from the University of Tennessee.
+                    </p>
+                  </details>
+                </li>
+                <li class="leading-block">
+                  <span class="blog-post-date">12 November, 2020 - 12pm EST/5pm GMT</span>
+                  <h4>
+                    Intro to
+                    <a href="https://github.com/vm6502q/qrack">qrack</a>: a framework for fast quantum simulation by
+                    Daniel Strano
+                  </h4>
+                  <!-- <h4><a href="https://www.youtube.com/watch?v=yxyqJDC4SUo" >YouTube Recording</a></h4> -->
+                  <iframe
+                    class="video"
+                    src="https://www.youtube-nocookie.com/embed/yxyqJDC4SUo"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+                  <br />
+                  <br />
+                  <details>
+                    <summary>About the talk</summary>
+                    <p>
+                      <strong><a href="https://github.com/vm6502q/qrack">vm6502q/qrack</a></strong>
+                      is a quantum computer simulation framework designed for the highest performance on the widest
+                      possible range of consumer-grade "classical" hardware platforms. It has 0 required external
+                      software dependencies besides C++11 standard, it optionally supports OpenCL accelerators back to
+                      the v1.1 standard, including multi-accelerator operation, and it prides itself on its "novel
+                      optimization layer." The speaker will outline the many features of the framework, including the
+                      theory behind the novel optimization layer, culminating in a simulator stack whose general use
+                      case is also its highest performance "Swiss Army knife" simulator, which has been integrated with
+                      a much wider developing quantum open source stack via plugins. Quantitative benchmarks will also
+                      be discussed, including performance on the quantum Fourier transform and an example of a "quantum
+                      volume"-type random universal circuit. Check out the project
+                      <a href="https://discordapp.com/invite/Gj3CHDy">Discord</a>
+                      for more info!
+                    </p>
+                  </details>
+                  <br />
+                  <details>
+                    <summary>About the speaker</summary>
+                    <p>
+                      <strong>Daniel Strano</strong> is senior software developer for PDHI (Basking Ridge, NJ). He holds
+                      a B.A. in physics and has worked as a data scientist or software engineer for companies including
+                      Pacific Northwest National Laboratories (Richland, WA) and S&A Technologies, LLC (Newark, NJ). For
+                      the past three years, he is the lead developer of the vm6502q/qrack quantum computing simulation
+                      framework, along with Benn Bollay, which has received a Unitary Fund grant. His personal research
+                      and literary blog is at ultraphrenia.com, including information and videos about his open source
+                      extensions to the OpenRelativity physics module for Unity3D, by the MIT Game Lab, to which he is a
+                      community contributor via a personal fork on GitHub.
+                    </p>
+                  </details>
+                </li>
+              </ul>
 
-                                <li class="leading-block"><span class="blog-post-date">20 May, 2021 - 12pm EST/5pm
-                                GMT</span>
-                                    <h4>Intro to <a href="https://github.com/pasqal-io/Pulser">Pulser</a>: Pulse simulation and design for neutral atoms by Loïc Henriet</h4>
-                                    <iframe class="video" src="https://www.youtube-nocookie.com/embed/Y4aM9G21tXk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                                    <br>
-                                    <details>
-                                        <summary>About the talk</summary>
-                                        <p> The manipulation of neutral atoms by light is at the heart of countless scientific discoveries in the field of quantum physics in the last three decades. The level of control that has been achieved at the single
-                                            particle level within arrays of optical traps, while preserving the fundamental properties of quantum matter (coherence, entanglement, superposition), makes these technologies prime candidates to implement disruptive
-                                            computation paradigms. In this talk, I will present <a href="https://github.com/pasqal-io/Pulser">pulser</a>, a recently developed open-source python framework enabling practitioners to control those devices
-                                            at the pulse level.</p>
-                                    </details>
-                                    <br>
-                                    <details>
-                                        <summary>About the speaker</summary>
-                                        <p><strong>Loïc Henriet</strong> holds an engineering degree and a PhD in theoretical physics from Ecole Polytechnique, in France. He subsequently worked as a researcher at the Institute for Photonic Sciences (ICFO)
-                                            in Barcelona, Spain. His research interests lied in the description of collective effects in light-matter systems. In June 2019, he joined Pasqal, a Paris-based quantum computing startup manufacturing quantum
-                                            processors powered by arrays of single atoms. Since then, he has been heading the quantum software developments.
-                                        </p>
-                                    </details>
-                                </li>
-
-                                <li class="leading-block"><span class="blog-post-date">18 March, 2021 - 12pm EST/5pm
-                                GMT</span>
-                                    <h4>Intro to <a href="http://github.com/tqsd/QuNetSim">QuNetSim</a>: A Software Framework for Quantum Networks by Stephen DiAdamo</h4>
-                                    <iframe class="video" src="https://www.youtube-nocookie.com/embed/MmdRLYh1_mI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                                    <br>
-                                    <br>
-                                    <details>
-                                        <summary>About the talk</summary>
-                                        <p><a href="http://github.com/tqsd/QuNetSim">QuNetSim</a> is a quantum-enabled network simulator that adds common quantum networking tasks like teleportation, superdense coding, sharing EPR pairs, etc, to aid in the
-                                            develop of quantum networking protocols. With QuNetSim, one can design and test robust quantum network protocols under various network conditions. In this presentation I will give an overview of what QuNetSim
-                                            does and demonstrate some examples of how it can be used.</p>
-                                    </details>
-                                    <br>
-                                    <details>
-                                        <summary>About the speaker</summary>
-                                        <p><strong>Stephen DiAdamo</strong> is an electrical engineering PhD student from TU Munich. After completing his bachelor's in computer science from the University of Toronto, he moved to Munich, Germany to complete
-                                            a mathematics master's degree at TU Munich and continued after as a PhD student. His research involves applications of entanglement in quantum networks as well as quantum simulation development.
-                                        </p>
-                                    </details>
-                                </li>
-
-                                <li class="leading-block"><span class="blog-post-date">28 January, 2021 - 12pm EST/5pm
-                                    GMT</span>
-                                    <h4>Intro to <a href="http://qutip.org/">QuTiP</a>: A Quantum Toolbox in Python by Shahnawaz Ahmed</h4>
-                                    <iframe class="video" src="https://www.youtube-nocookie.com/embed/2tF_4ZJAuYY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                                    <br>
-                                    <br>
-                                    <details>
-                                        <summary>About the talk</summary>
-                                        <p><a href="http://qutip.org/">QuTiP</a>: A quantum toolbox in Python, is one of the most popular tools to simulate open quantum systems – but it has expanded beyond that over the years. It is a simple but powerful
-                                            library that, used by students, researchers, engineers, is having a tremendous impact on quantum science research. QuTiP is also Unitary Fund’s first affiliated project. In this talk, I will introduce the library
-                                            and take the example of some new developments in QuTiP to show the ease with which one can simulate open quantum systems as well as contribute to the development of such open-source software tools to promote
-                                            reproducibility and therefore accelerate the adoption of a particular simulation technique across the research community.</p>
-                                    </details>
-                                    <br>
-                                    <details>
-                                        <summary>About the speaker</summary>
-                                        <p><strong>Shahnawaz Ahmed</strong> is a graduate student at the Wallenberg Center for Quantum Technology at Chalmers University, Sweden. His research interest lies in the intersection of machine learning and quantum
-                                            computing. He also works on numerical approaches to solve problems in open quantum systems and is a member of the QuTiP development team.</p>
-                                    </details>
-                                </li>
-                            </ul>
-                            <ul style="list-style-type: none;">
-                                <li class="leading-block"><span class="blog-post-date">03 December, 2020 - 12pm EST/5pm
-                                    GMT</span>
-                                    <h4>Intro to <a href="https://qcor.ornl.gov/">qcor</a>: Extending C++ for Heterogeneous Quantum-Classical Computing by Alex McCaskey</h4>
-                                    <iframe class="video" src="https://www.youtube-nocookie.com/embed/GzslhEnHUHI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                                    <br>
-                                    <br>
-                                    <details>
-                                        <summary>About the talk</summary>
-                                        <p>We present <strong><a href="https://qcor.ornl.gov/">qcor</a></strong> - a language extension to C++ and compiler implementation that enables heterogeneous quantum-classical programming, compilation, and execution
-                                            in a single-source context. Our work provides a first-of-its-kind C++ compiler enabling high-level quantum kernel (function) expression in a quantum-language agnostic manner, as well as a hardware-agnostic,
-                                            retargetable compiler workflow targeting a number of physical and virtual quantum computing backends. qcor leverages novel Clang plugin interfaces and builds upon the <a href="https://github.com/eclipse/xacc">
-                                            XACC</a> system-level quantum programming framework to provide a state-of-the-art integration mechanism for quantum-classical compilation that leverages the best from the community at-large. qcor translates
-                                            quantum kernels ultimately to the XACC intermediate representation, and provides user-extensible hooks for quantum compilation routines like circuit optimization, analysis, and placement. This work details the
-                                            overall architecture and compiler workflow for qcor, and provides a number of illuminating programming examples demonstrating its utility for near-term variational tasks, quantum algorithm expression, and feed-forward
-                                            error correction schemes.</p>
-                                    </details>
-                                    <br>
-                                    <details>
-                                        <summary>About the speaker</summary>
-                                        <p><strong>Alex McCaskey</strong> is a research scientist in the Computer Science and Mathematics Division at Oak Ridge National Laboratory. He serves as the Software Lead for the Quantum Computing Institute at ORNL
-                                            and is the Project Lead for the XACC quantum framework and the QCOR quantum-classical C++ compiler. He received his Masters in Physics from Virginia Tech and BS degrees in Physics and Mathematics from the University
-                                            of Tennessee.</p>
-                                    </details>
-                                </li>
-                                <li class="leading-block"><span class="blog-post-date">12 November, 2020 - 12pm EST/5pm
-                                    GMT</span>
-                                    <h4>Intro to <a href="https://github.com/vm6502q/qrack">qrack</a>: a framework for fast quantum simulation by Daniel Strano</h4>
-                                    <!-- <h4><a href="https://www.youtube.com/watch?v=yxyqJDC4SUo" >YouTube Recording</a></h4> -->
-                                    <iframe class="video" src="https://www.youtube-nocookie.com/embed/yxyqJDC4SUo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                                    <br>
-                                    <br>
-                                    <details>
-                                        <summary>About the talk</summary>
-                                        <p><strong><a href="https://github.com/vm6502q/qrack">vm6502q/qrack</a></strong> is a quantum computer simulation framework designed for the highest performance on the widest possible range of consumer-grade "classical"
-                                            hardware platforms. It has 0 required external software dependencies besides C++11 standard, it optionally supports OpenCL accelerators back to the v1.1 standard, including multi-accelerator operation, and it
-                                            prides itself on its "novel optimization layer." The speaker will outline the many features of the framework, including the theory behind the novel optimization layer, culminating in a simulator stack whose
-                                            general use case is also its highest performance "Swiss Army knife" simulator, which has been integrated with a much wider developing quantum open source stack via plugins. Quantitative benchmarks will also
-                                            be discussed, including performance on the quantum Fourier transform and an example of a "quantum volume"-type random universal circuit. Check out the project <a href="https://discordapp.com/invite/Gj3CHDy">Discord</a>                                            for more info!</p>
-                                    </details>
-                                    <br>
-                                    <details>
-                                        <summary>About the speaker</summary>
-                                        <p><strong>Daniel Strano</strong> is senior software developer for PDHI (Basking Ridge, NJ). He holds a B.A. in physics and has worked as a data scientist or software engineer for companies including Pacific Northwest
-                                            National Laboratories (Richland, WA) and S&A Technologies, LLC (Newark, NJ). For the past three years, he is the lead developer of the vm6502q/qrack quantum computing simulation framework, along with Benn Bollay,
-                                            which has received a Unitary Fund grant. His personal research and literary blog is at ultraphrenia.com, including information and videos about his open source extensions to the OpenRelativity physics module
-                                            for Unity3D, by the MIT Game Lab, to which he is a community contributor via a personal fork on GitHub. </p>
-                                    </details>
-                                </li>
-                            </ul>
-
-                                <footer class="footer leading-arrow light-arrow">
-                                    This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br> If you have suggestions for changes then please open up a pull request!
-                                    <br>
-                                    <br>
-                                    <table>
-                                        <tr>
-                                            <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                                class="fa fa-twitter"></i></a></th>
-                                            <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                                class="fa fa-twitch"></i></a></th>
-                                            <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                                class="fa fa-youtube"></i></a></th>
-                                            <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                                class="fab fa-discord"></i></a></th>
-                                        </tr>
-                                    </table> &copy;2020 Unitary Fund
-                                </footer>
-                    </div>
-                    <div class="col-1" id="menu-container">
-                        <table style="width:auto; margin-right:0px; margin-left: auto;">
-                            <tr>
-                                <th style="text-align: right;"><a href="https://twitter.com/unitaryfund"><i
-                                            class="fa fa-twitter"></i></a></th>
-                                <th style="text-align: right;"><a href="https://twitch.tv/unitaryfund"><i
-                                            class="fa fa-twitch"></i></a></th>
-                                <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i
-                                            class="fa fa-youtube"></i></a></th>
-                                <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
-                                            class="fab fa-discord"></i></a></th>
-                            </tr>
-                        </table>
-                        <p class="light" id="menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html" class="active">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                    <div id="mobile-menu-container">
-                        <p class="light" id="mobile-menu">
-                            <a href="grants.html">grants</a>
-                            <a href="ideas.html">ideas</a>
-                            <a href="research.html">research</a>
-                            <a href="mitiq.html">mitiq</a>
-                            <a href="talks.html" class="active">events</a>
-                            <a href="faq.html">faq</a>
-                            <a href="blog.html">blog</a>
-                            <a href="careers.html">careers</a>
-                            <a href="donate.html">donate</a>
-                            <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
-                            <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
-                        </p>
-                    </div>
-                </div>
-            </section>
-        </main>
+              <footer class="footer leading-arrow light-arrow">
+                This website is hosted on
+                <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>.
+                <br />
+                If you have suggestions for changes then please open up a pull request!
+                <br />
+                <br />
+                <table>
+                  <tr>
+                    <th style="text-align: right">
+                      <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"
+                        ><i class="fa fa-youtube"></i
+                      ></a>
+                    </th>
+                    <th style="text-align: right">
+                      <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                    </th>
+                  </tr>
+                </table>
+                &copy;2020 Unitary Fund
+              </footer>
+            </div>
+            <div class="col-1" id="menu-container">
+              <table style="width: auto; margin-right: 0px; margin-left: auto">
+                <tr>
+                  <th style="text-align: right">
+                    <a href="https://twitter.com/unitaryfund"><i class="fa fa-twitter"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://twitch.tv/unitaryfund"><i class="fa fa-twitch"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a>
+                  </th>
+                  <th style="text-align: right">
+                    <a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a>
+                  </th>
+                </tr>
+              </table>
+              <p class="light" id="menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html" class="active">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+            <div id="mobile-menu-container">
+              <p class="light" id="mobile-menu">
+                <a href="grants.html">grants</a>
+                <a href="ideas.html">ideas</a>
+                <a href="research.html">research</a>
+                <a href="mitiq.html">mitiq</a>
+                <a href="talks.html" class="active">events</a>
+                <a href="faq.html">faq</a>
+                <a href="blog.html">blog</a>
+                <a href="careers.html">careers</a>
+                <a href="donate.html">donate</a>
+                <a href="https://shop.spreadshirt.com/unitaryfund/">shop</a>
+                <a href="https://unitaryfund.typeform.com/to/j0kAOd" target="_blank" class="highlight">apply</a>
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
     <script>
-        var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
-        mobileMenuContainer = document.querySelector("#mobile-menu-container");
-        mobileMenuIcon.addEventListener("click", function() {
-            mobileMenuIcon.classList.toggle("is-active");
-            mobileMenuContainer.classList.toggle("active");
-        });
+      var mobileMenuIcon = document.querySelector("#mobile-menu-icon")
+      mobileMenuContainer = document.querySelector("#mobile-menu-container")
+      mobileMenuIcon.addEventListener("click", function () {
+        mobileMenuIcon.classList.toggle("is-active")
+        mobileMenuContainer.classList.toggle("active")
+      })
     </script>
-</body>
-
+  </body>
 </html>

--- a/talks.html
+++ b/talks.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/talks.html
+++ b/talks.html
@@ -119,7 +119,6 @@
                                     <br>
 
                                 </li>
-                                <br>
                                 <li class="leading-block"><span class="blog-post-date">23 November, 2021 - 12pm EST/5pm GMT</span>
                                     <h4><a href="https://github.com/pedrorrivero/qrand">qrand</a>: A multi-platform and multi-protocol quantum random number generator for arbitrary probability distributions by Pedro Rivero</h4>
                                     <iframe class="video" src="https://www.youtube-nocookie.com/embed/srZddqGdVNE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -154,7 +153,7 @@
                                         <p>Erik and Kenneth both are researchers and developers working on pyGSTi at Sandia National Labs.
                                         </p>
                                     </details>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">19 August, 2021 - 12pm EST/5pm
                                 GMT</span>
                                     <h4>Intro to <a href="https://github.com/xvzcf/VeriFrodo">VeriFrodo</a>: The post-quantum cryptographic software ecosystem by Goutam Tamvada</h4>
@@ -171,7 +170,7 @@
                                             2 years.
                                         </p>
                                     </details>
-                                </li><br>
+                                </li>
 
 
                                 <li class="leading-block"><span class="blog-post-date">20 May, 2021 - 12pm EST/5pm
@@ -194,7 +193,7 @@
                                             processors powered by arrays of single atoms. Since then, he has been heading the quantum software developments.
                                         </p>
                                     </details>
-                                </li><br>
+                                </li>
 
                                 <li class="leading-block"><span class="blog-post-date">18 March, 2021 - 12pm EST/5pm
                                 GMT</span>
@@ -215,7 +214,7 @@
                                             a mathematics master's degree at TU Munich and continued after as a PhD student. His research involves applications of entanglement in quantum networks as well as quantum simulation development.
                                         </p>
                                     </details>
-                                </li><br>
+                                </li>
 
                                 <li class="leading-block"><span class="blog-post-date">28 January, 2021 - 12pm EST/5pm
                                     GMT</span>
@@ -236,7 +235,7 @@
                                         <p><strong>Shahnawaz Ahmed</strong> is a graduate student at the Wallenberg Center for Quantum Technology at Chalmers University, Sweden. His research interest lies in the intersection of machine learning and quantum
                                             computing. He also works on numerical approaches to solve problems in open quantum systems and is a member of the QuTiP development team.</p>
                                     </details>
-                                </li><br>
+                                </li>
                             </ul>
                             <ul id="seminar-list" style="list-style-type: none;">
                                 <li class="leading-block"><span class="blog-post-date">03 December, 2020 - 12pm EST/5pm
@@ -262,7 +261,7 @@
                                             and is the Project Lead for the XACC quantum framework and the QCOR quantum-classical C++ compiler. He received his Masters in Physics from Virginia Tech and BS degrees in Physics and Mathematics from the University
                                             of Tennessee.</p>
                                     </details>
-                                </li><br>
+                                </li>
                                 <li class="leading-block"><span class="blog-post-date">12 November, 2020 - 12pm EST/5pm
                                     GMT</span>
                                     <h4>Intro to <a href="https://github.com/vm6502q/qrack">qrack</a>: a framework for fast quantum simulation by Daniel Strano</h4>

--- a/talks.html
+++ b/talks.html
@@ -64,7 +64,7 @@
                                     </span>
                                 </button>
                         </div>
-                        <p class="subtitle leading-arrow"><a name="calendar">Unitary Fund Community Calendar</a>
+                        <p class="subtitle leading-arrow"><a name="calendar">Unitary Fund Community Calendar</a></p>
                             <p>
                                 Want to keep up to date with all the cool stuff the Unitary Fund community is up to? Take a look at the calendar below and add it to your favorite calendar app!</p>
                             <div class="ae-emd-cal" data-calendar="kn360162" data-calendars="kn360162" data-calendars-selected="kn360162" data-configure="true" data-title="" data-title-show="true" data-today="true" data-datenav="true" data-date="true" data-monthweektoggle="true"
@@ -79,7 +79,6 @@
                                     document.getElementsByTagName("body")[0].appendChild(e);
                                 })();
                             </script>
-                        </p>
 
                         <p>
                             <p class="subtitle leading-arrow"><a name="talks">Quantum Software Talks</a></p>

--- a/talks.html
+++ b/talks.html
@@ -91,7 +91,8 @@
                 data-logo="false"
                 data-defaultview="schedule"
                 data-firstday="0"
-                data-datetimeformat="2"></div>
+                data-datetimeformat="2"
+              ></div>
               <script type="text/javascript">
                 ;(function () {
                   var e = document.createElement("script")
@@ -129,8 +130,9 @@
                       type="text/javascript"
                       src="https://cdn.addevent.com/libs/atc/1.6.1/atc.min.js"
                       async
-                      defer></script
-                  ></span>
+                      defer
+                    ></script>
+                  </span>
                   <h4>
                     <a href="https://qutip.org/docs/latest/guide/guide-qip.html">qutip-qip</a>: Pulse-level circuits
                     simulation by Boxi Li
@@ -140,7 +142,8 @@
                     src="https://www.youtube-nocookie.com/embed/-q5a38Pw7Rg"
                     frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    allowfullscreen></iframe>
+                    allowfullscreen
+                  ></iframe>
                   <details>
                     <summary>About the talk</summary>
                     <p>
@@ -161,12 +164,13 @@
                   <details>
                     <summary>About the speaker</summary>
                     <p>
-                      <strong>Boxi Li</strong> is a PhD candidate at Forschungszentrum Jülich (Jülich research centre)
-                      in Germany, working on quantum control and modelling for superconducting qubits. I did my
-                      Bachelors at the University of Heidelberg and went to ETHZ for a master's degree, during which I
-                      also enjoyed a short stay at TU Delft, exploring the magic of quantum networks. I started my
-                      contribution to QuTiP from a GSoC project in 2019 and joined the development team thereafter,
-                      mainly maintaining the qutip-qip repository.
+                      <strong>Boxi Li</strong>
+                      is a PhD candidate at Forschungszentrum Jülich (Jülich research centre) in Germany, working on
+                      quantum control and modelling for superconducting qubits. I did my Bachelors at the University of
+                      Heidelberg and went to ETHZ for a master's degree, during which I also enjoyed a short stay at TU
+                      Delft, exploring the magic of quantum networks. I started my contribution to QuTiP from a GSoC
+                      project in 2019 and joined the development team thereafter, mainly maintaining the qutip-qip
+                      repository.
                     </p>
                   </details>
                   <br />
@@ -182,7 +186,8 @@
                     src="https://www.youtube-nocookie.com/embed/srZddqGdVNE"
                     frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    allowfullscreen></iframe>
+                    allowfullscreen
+                  ></iframe>
                   <details>
                     <summary>About the talk</summary>
                     <p>
@@ -199,8 +204,9 @@
                   <details>
                     <summary>About the speaker</summary>
                     <p>
-                      <strong>Pedro Rivero</strong> is an algorithm and quantum software developer at Argonne National
-                      Laboratory and is enrolled in a a PhD course at the Illinois Institute of Technology.
+                      <strong>Pedro Rivero</strong>
+                      is an algorithm and quantum software developer at Argonne National Laboratory and is enrolled in a
+                      a PhD course at the Illinois Institute of Technology.
                     </p>
                   </details>
                 </li>
@@ -215,7 +221,8 @@
                     src="https://www.youtube-nocookie.com/embed/45YXL49MSx4"
                     frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    allowfullscreen></iframe>
+                    allowfullscreen
+                  ></iframe>
                   <p>
                     <a href="https://zenodo.org/record/5715199"> Sample Jupyter notebooks from the talk</a>
                   </p>
@@ -253,7 +260,8 @@
                     src="https://www.youtube-nocookie.com/embed/rVMcplTyPpg"
                     frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    allowfullscreen></iframe>
+                    allowfullscreen
+                  ></iframe>
                   <details>
                     <summary>About the talk</summary>
                     <p>
@@ -267,9 +275,9 @@
                   <details>
                     <summary>About the speaker</summary>
                     <p>
-                      <strong>Goutam Tamvada</strong> has a Bachelor of Applied Science in Computer Engineering from the
-                      University of Waterloo, and has been working on open source software for the Open Quantum Safe
-                      project for the past 2 years.
+                      <strong>Goutam Tamvada</strong>
+                      has a Bachelor of Applied Science in Computer Engineering from the University of Waterloo, and has
+                      been working on open source software for the Open Quantum Safe project for the past 2 years.
                     </p>
                   </details>
                 </li>
@@ -286,7 +294,8 @@
                     src="https://www.youtube-nocookie.com/embed/Y4aM9G21tXk"
                     frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    allowfullscreen></iframe>
+                    allowfullscreen
+                  ></iframe>
                   <br />
                   <details>
                     <summary>About the talk</summary>
@@ -305,12 +314,13 @@
                   <details>
                     <summary>About the speaker</summary>
                     <p>
-                      <strong>Loïc Henriet</strong> holds an engineering degree and a PhD in theoretical physics from
-                      Ecole Polytechnique, in France. He subsequently worked as a researcher at the Institute for
-                      Photonic Sciences (ICFO) in Barcelona, Spain. His research interests lied in the description of
-                      collective effects in light-matter systems. In June 2019, he joined Pasqal, a Paris-based quantum
-                      computing startup manufacturing quantum processors powered by arrays of single atoms. Since then,
-                      he has been heading the quantum software developments.
+                      <strong>Loïc Henriet</strong>
+                      holds an engineering degree and a PhD in theoretical physics from Ecole Polytechnique, in France.
+                      He subsequently worked as a researcher at the Institute for Photonic Sciences (ICFO) in Barcelona,
+                      Spain. His research interests lied in the description of collective effects in light-matter
+                      systems. In June 2019, he joined Pasqal, a Paris-based quantum computing startup manufacturing
+                      quantum processors powered by arrays of single atoms. Since then, he has been heading the quantum
+                      software developments.
                     </p>
                   </details>
                 </li>
@@ -327,28 +337,31 @@
                     src="https://www.youtube-nocookie.com/embed/MmdRLYh1_mI"
                     frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    allowfullscreen></iframe>
+                    allowfullscreen
+                  ></iframe>
                   <br />
                   <br />
                   <details>
                     <summary>About the talk</summary>
                     <p>
-                      <a href="http://github.com/tqsd/QuNetSim">QuNetSim</a> is a quantum-enabled network simulator that
-                      adds common quantum networking tasks like teleportation, superdense coding, sharing EPR pairs,
-                      etc, to aid in the develop of quantum networking protocols. With QuNetSim, one can design and test
-                      robust quantum network protocols under various network conditions. In this presentation I will
-                      give an overview of what QuNetSim does and demonstrate some examples of how it can be used.
+                      <a href="http://github.com/tqsd/QuNetSim">QuNetSim</a>
+                      is a quantum-enabled network simulator that adds common quantum networking tasks like
+                      teleportation, superdense coding, sharing EPR pairs, etc, to aid in the develop of quantum
+                      networking protocols. With QuNetSim, one can design and test robust quantum network protocols
+                      under various network conditions. In this presentation I will give an overview of what QuNetSim
+                      does and demonstrate some examples of how it can be used.
                     </p>
                   </details>
                   <br />
                   <details>
                     <summary>About the speaker</summary>
                     <p>
-                      <strong>Stephen DiAdamo</strong> is an electrical engineering PhD student from TU Munich. After
-                      completing his bachelor's in computer science from the University of Toronto, he moved to Munich,
-                      Germany to complete a mathematics master's degree at TU Munich and continued after as a PhD
-                      student. His research involves applications of entanglement in quantum networks as well as quantum
-                      simulation development.
+                      <strong>Stephen DiAdamo</strong>
+                      is an electrical engineering PhD student from TU Munich. After completing his bachelor's in
+                      computer science from the University of Toronto, he moved to Munich, Germany to complete a
+                      mathematics master's degree at TU Munich and continued after as a PhD student. His research
+                      involves applications of entanglement in quantum networks as well as quantum simulation
+                      development.
                     </p>
                   </details>
                 </li>
@@ -356,14 +369,16 @@
                 <li class="leading-block">
                   <span class="blog-post-date">28 January, 2021 - 12pm EST/5pm GMT</span>
                   <h4>
-                    Intro to <a href="http://qutip.org/">QuTiP</a>: A Quantum Toolbox in Python by Shahnawaz Ahmed
+                    Intro to
+                    <a href="http://qutip.org/">QuTiP</a>: A Quantum Toolbox in Python by Shahnawaz Ahmed
                   </h4>
                   <iframe
                     class="video"
                     src="https://www.youtube-nocookie.com/embed/2tF_4ZJAuYY"
                     frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    allowfullscreen></iframe>
+                    allowfullscreen
+                  ></iframe>
                   <br />
                   <br />
                   <details>
@@ -383,10 +398,11 @@
                   <details>
                     <summary>About the speaker</summary>
                     <p>
-                      <strong>Shahnawaz Ahmed</strong> is a graduate student at the Wallenberg Center for Quantum
-                      Technology at Chalmers University, Sweden. His research interest lies in the intersection of
-                      machine learning and quantum computing. He also works on numerical approaches to solve problems in
-                      open quantum systems and is a member of the QuTiP development team.
+                      <strong>Shahnawaz Ahmed</strong>
+                      is a graduate student at the Wallenberg Center for Quantum Technology at Chalmers University,
+                      Sweden. His research interest lies in the intersection of machine learning and quantum computing.
+                      He also works on numerical approaches to solve problems in open quantum systems and is a member of
+                      the QuTiP development team.
                     </p>
                   </details>
                 </li>
@@ -395,15 +411,17 @@
                 <li class="leading-block">
                   <span class="blog-post-date">03 December, 2020 - 12pm EST/5pm GMT</span>
                   <h4>
-                    Intro to <a href="https://qcor.ornl.gov/">qcor</a>: Extending C++ for Heterogeneous
-                    Quantum-Classical Computing by Alex McCaskey
+                    Intro to
+                    <a href="https://qcor.ornl.gov/">qcor</a>: Extending C++ for Heterogeneous Quantum-Classical
+                    Computing by Alex McCaskey
                   </h4>
                   <iframe
                     class="video"
                     src="https://www.youtube-nocookie.com/embed/GzslhEnHUHI"
                     frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    allowfullscreen></iframe>
+                    allowfullscreen
+                  ></iframe>
                   <br />
                   <br />
                   <details>
@@ -431,11 +449,12 @@
                   <details>
                     <summary>About the speaker</summary>
                     <p>
-                      <strong>Alex McCaskey</strong> is a research scientist in the Computer Science and Mathematics
-                      Division at Oak Ridge National Laboratory. He serves as the Software Lead for the Quantum
-                      Computing Institute at ORNL and is the Project Lead for the XACC quantum framework and the QCOR
-                      quantum-classical C++ compiler. He received his Masters in Physics from Virginia Tech and BS
-                      degrees in Physics and Mathematics from the University of Tennessee.
+                      <strong>Alex McCaskey</strong>
+                      is a research scientist in the Computer Science and Mathematics Division at Oak Ridge National
+                      Laboratory. He serves as the Software Lead for the Quantum Computing Institute at ORNL and is the
+                      Project Lead for the XACC quantum framework and the QCOR quantum-classical C++ compiler. He
+                      received his Masters in Physics from Virginia Tech and BS degrees in Physics and Mathematics from
+                      the University of Tennessee.
                     </p>
                   </details>
                 </li>
@@ -452,7 +471,8 @@
                     src="https://www.youtube-nocookie.com/embed/yxyqJDC4SUo"
                     frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    allowfullscreen></iframe>
+                    allowfullscreen
+                  ></iframe>
                   <br />
                   <br />
                   <details>
@@ -477,14 +497,15 @@
                   <details>
                     <summary>About the speaker</summary>
                     <p>
-                      <strong>Daniel Strano</strong> is senior software developer for PDHI (Basking Ridge, NJ). He holds
-                      a B.A. in physics and has worked as a data scientist or software engineer for companies including
-                      Pacific Northwest National Laboratories (Richland, WA) and S&A Technologies, LLC (Newark, NJ). For
-                      the past three years, he is the lead developer of the vm6502q/qrack quantum computing simulation
-                      framework, along with Benn Bollay, which has received a Unitary Fund grant. His personal research
-                      and literary blog is at ultraphrenia.com, including information and videos about his open source
-                      extensions to the OpenRelativity physics module for Unity3D, by the MIT Game Lab, to which he is a
-                      community contributor via a personal fork on GitHub.
+                      <strong>Daniel Strano</strong>
+                      is senior software developer for PDHI (Basking Ridge, NJ). He holds a B.A. in physics and has
+                      worked as a data scientist or software engineer for companies including Pacific Northwest National
+                      Laboratories (Richland, WA) and S&A Technologies, LLC (Newark, NJ). For the past three years, he
+                      is the lead developer of the vm6502q/qrack quantum computing simulation framework, along with Benn
+                      Bollay, which has received a Unitary Fund grant. His personal research and literary blog is at
+                      ultraphrenia.com, including information and videos about his open source extensions to the
+                      OpenRelativity physics module for Unity3D, by the MIT Game Lab, to which he is a community
+                      contributor via a personal fork on GitHub.
                     </p>
                   </details>
                 </li>

--- a/talks.html
+++ b/talks.html
@@ -89,12 +89,12 @@
                             </p>
 
                             <p class="subtitle leading-arrow">Upcoming talks</p>
-                            <ul id="seminar-list" style="list-style-type: none;">
+                            <ul style="list-style-type: none;">
 
                             </ul>
 
                             <p class="subtitle leading-arrow">Previous talks</p>
-                            <ul id="seminar-list" style="list-style-type: none;">
+                            <ul style="list-style-type: none;">
                                 <li class="leading-block"><span class="blog-post-date">7 April, 2022 - 12pm EST/5pm GMT 
                                     <!-- <a title="Add to Calendar" class="addeventatc" data-id="jg13211859" href="https://www.addevent.com/event/jg13211859" target="_blank" rel="nofollow">Add to Calendar</a> -->
                                     <script type="text/javascript" src="https://cdn.addevent.com/libs/atc/1.6.1/atc.min.js" async defer></script></span>
@@ -237,7 +237,7 @@
                                     </details>
                                 </li>
                             </ul>
-                            <ul id="seminar-list" style="list-style-type: none;">
+                            <ul style="list-style-type: none;">
                                 <li class="leading-block"><span class="blog-post-date">03 December, 2020 - 12pm EST/5pm
                                     GMT</span>
                                     <h4>Intro to <a href="https://qcor.ornl.gov/">qcor</a>: Extending C++ for Heterogeneous Quantum-Classical Computing by Alex McCaskey</h4>

--- a/talks.html
+++ b/talks.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" type="text/css" href="hamburgers.min.css" />
 
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
-    <style type="text/css">
+    <style>
       #mc_embed_signup {
         background: #fff;
         clear: left;

--- a/talks.html
+++ b/talks.html
@@ -288,34 +288,6 @@
                                 </li>
                             </ul>
 
-                            <footer class="footer leading-arrow light-arrow">
-                                This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br> If you have suggestions for changes then please open up a pull request!
-                                <br>
-                                <br>
-                                <details>
-                                    <summary>About the speaker</summary>
-                                    <p><strong>Daniel Strano</strong> is senior software developer for PDHI (Basking Ridge, NJ). He holds a B.A. in physics and has worked as a data scientist or software engineer for companies including Pacific Northwest
-                                        National Laboratories (Richland, WA) and S&A Technologies, LLC (Newark, NJ). For the past three years, he is the lead developer of the vm6502q/qrack quantum computing simulation framework, along with Benn Bollay,
-                                        which has received a Unitary Fund grant. His personal research and literary blog is at ultraphrenia.com, including information and videos about his open source extensions to the OpenRelativity physics module for
-                                        Unity3D, by the MIT Game Lab, to which he is a community contributor via a personal fork on GitHub. </p>
-                                </details>
-                                </li>
-                                </ul>
-                                <p class="subtitle leading-arrow"><a name="unitaryhack21">unitaryHACK 2021</a></p>
-                                <a href="http://hack2021.unitary.fund" name="unitaryHACK">
-                                    <figure>
-                                        <img style="max-width: 50%;
-                                    height: auto; margin: auto;
-                            display: block;" src="./logos/unitaryHACK-logo-date.png" alt="unitaryHACK" />
-                                    </figure>
-                                </a>
-                                The Unitary Fund was proud to host our first quantum open source hackathon, called <a href="https://unitaryfund.github.io/unitaryhack/index.html">unitaryHACK</a>, with free swag and bounties on May 14-30th 2021! We had
-                                over $2K in bounties for tagged issues in quantum open source projects for folks that made maintainer-approved pull requests to a list of selected quantum open source projects. All participants got digital swag when they
-                                made approved Pull Requests (PR)s, and random participants that made 1 quality Pull Request (PR)s got a swag pack in the mail.
-
-                                <p>
-                                    To check out the results from the hackathon see the <a href="https://unitaryfund.github.io/unitaryhack/results.html">event page here!</a>
-                                </p>
                                 <footer class="footer leading-arrow light-arrow">
                                     This website is hosted on <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>. <br> If you have suggestions for changes then please open up a pull request!
                                     <br>


### PR DESCRIPTION
This PR ensures the main/root HTML files pass the important parts of an HTML validator, such as https://validator.w3.org/, so that a formatter can be run.

The need for this arose when adding myself to the UF team section (https://github.com/unitaryfund/unitary-fund/pull/221), and I found my editor not being able to format the html due to problems in the file. Browsers are very adaptable creatures, and hence still render the technically ill-formed HTML, but I think have standardized formatting helps prevent future issues.

**Things to note:**
1. A formatter was applied to html previously (https://github.com/unitaryfund/unitary-fund/commit/7d248f13d5d54ba3bed0eb214a8b65d9db51fffc), yet problems have crept in since, as there is no specification for what formatter was used. Hence, I've added prettier to the repo, which has integrations with major editors and can run on save.
2. I've set the line width — somewhat arbitrarily — to [120](https://github.com/unitaryfund/unitary-fund/blob/45ba5ed1df6e7ab9831994fec1f4461930727a83/.prettierrc.yaml#L1). The default is 80, and they [recommend](https://prettier.io/docs/en/options.html#print-width) not going much above this, but because we are only using prettier for HTML, I think this is okay.
3. I did not format any HTML in `jobs/`, since those pages are not frequently used, but I can if desired. I also did not format anything in `posts/` as I believe the HTML there to be auto-generated in some way and hence should not be edited manually. Please correct me if that is wrong.
4. There are some validations that still do not pass. E.g. I did not remove _all_ occurrences of the `frameborder` found in `iframe`s. However, as you can read [on stackoverflow](https://stackoverflow.com/a/3601946), it's not _that_ important. Another example is that the `<center>` tag is no longer valid HTML5, and should be replaced using CSS (replace `center` with `p` and add inline `style="text-align:center"`).
5. Finally, there are some very subtle differences in styling this PR introduces, and I've done my best to keep it to an absolute minimum. The following is the only visual difference I have noticed (subtle spacing differences above grant year).

| before | after |
| --- | --- |
| <img width="1792" alt="Screen Shot 2022-05-17 at 11 32 02 PM" src="https://user-images.githubusercontent.com/12703123/168972841-d80dcf1a-4cde-42e8-8060-b82bda73dc77.png"> | <img width="1792" alt="Screen Shot 2022-05-17 at 11 31 58 PM" src="https://user-images.githubusercontent.com/12703123/168972873-e3067e3c-d3df-4ff9-8223-f80004b66034.png"> |

---

Merging this into the [`ns-add-me`](https://github.com/unitaryfund/unitary-fund/tree/ns-add-me) branch as it was easier to start development from there.


