### PR TITLE
Add grant to Matt Tourens for QCNN tool

### DIFF
--- a/grants.html
+++ b/grants.html
@@ -230,7 +230,7 @@
                 <li>
                   <img class="grant-image" src="images/dummy.png" alt="grant" />
                   <p>
-                    To Lorenzo Buffoni, to develop
+                    To <b>Lorenzo Buffoni</b>, to develop
                     <a class="recipient-link" href="https://github.com/Buffoni/SQWalk">SQWalk</a>, A Stochastic Quantum
                     Walk simulator based on QuTiP.
                   </p>
@@ -238,7 +238,7 @@
                 <li>
                   <img class="grant-image" src="images/dummy.png" alt="grant" />
                   <p>
-                    To Jonas Schwab and the ALF collaboration, to develop
+                    To <b>Jonas Schwab and the ALF collaboration</b>, to develop
                     <a class="recipient-link" href="https://git.physik.uni-wuerzburg.de/ALF/pyALF">pyALF</a>, the Python
                     interface of the ALF project, a powerful and flexible package for Quantum Monte Carlo simulations of
                     fermion systems.
@@ -259,7 +259,7 @@
                 <li>
                   <img class="grant-image" src="images/dummy.png" alt="grant" />
                   <p>
-                    To Diego Ariel Wisniacki, Martin Larocca, Emiliano Manuel Fortes, Julian Matias Ruffinelli to
+                    To <b>Diego Ariel Wisniacki, Martin Larocca, Emiliano Manuel Fortes, Julian Matias Ruffinelli</b> to
                     develop Krylov evolution algorithms integrated with QuTiP. [<a
                       href="https://arxiv.org/abs/2010.03598"
                       >K-GRAPE</a
@@ -275,7 +275,7 @@
                 <li>
                   <img class="grant-image" src="images/dummy.png" alt="grant" />
                   <p>
-                    To Reem Larabi to add more visualization improvements to the %debug tool in Q# by expanding its
+                    To <b>Reem Larabi</b> to add more visualization improvements to the %debug tool in Q# by expanding its
                     current set of controls.
                   </p>
                 </li>
@@ -283,7 +283,7 @@
                 <li>
                   <img class="grant-image" src="images/dummy.png" alt="grant" />
                   <p>
-                    To Alessandro Luongo and Armando Bellante to develop
+                    To <b>Alessandro Luongo</b> and <b>Armando Bellante</b> to develop
                     <a class="recipient-link" href="https://quantumalgorithms.org">Quantumalgorithms.org</a>
                     an open-source web book collecting in an organized manner lectures notes around quantum algorithms
                     for information processing, data analysis and machine learning.
@@ -363,7 +363,7 @@
                 <li>
                   <img class="grant-image" src="images/dummy.png" alt="grant" />
                   <p>
-                    To Oscar Higgott, to continue developing and maintaining
+                    To <b>Oscar Higgott</b>, to continue developing and maintaining
                     <a class="recipient-link" href="https://github.com/oscarhiggott/PyMatching">PyMatching</a>, a Python
                     package for decoding quantum error correcting codes with minimum-weight perfect matching (MWPM). [<a
                       href="https://arxiv.org/abs/2105.13082"
@@ -375,7 +375,7 @@
                 <li>
                   <img class="grant-image" src="images/dummy.png" alt="grant" />
                   <p>
-                    To Nicola Mosco, to develop
+                    To <b>Nicola Mosco</b>, to develop
                     <a class="recipient-link" href="https://gitlab.com/homodyne-ct/MartaCT.jl">Marta CT</a>, a software
                     package in Julia for medical diagnostics that uses a quantum-tomography-inspired technique for state
                     reconstruction in order to reduce the radiation dose patients receive. [<a
@@ -405,7 +405,7 @@
                 <li>
                   <img class="grant-image" src="images/dummy.png" alt="grant" />
                   <p>
-                    To Pedro Rivero Ramírez for
+                    To <b>Pedro Rivero Ramírez</b> for
                     <a class="recipient-link" href="https://github.com/pedrorrivero/qrand/">QRand</a>, a multi-platform
                     quantum random number generator library integrated with numpy.
                   </p>

--- a/grants.html
+++ b/grants.html
@@ -87,6 +87,14 @@
               <h4 class="grant-year">2022 Grants</h4>
               <ul class="grant-list">
                 <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="dynamic-qcnn" />
+                  <p>
+                    To
+                    <b>Matt Tourens</b>, to develop
+                    <a href="https://github.com/matt-lourens/dynamic-qcnn">Dynamic QCNN</a>, a tool to generate quantum convolutional neural network models programmatically.
+                  </p>
+                </li>
+                <li>
                   <img class="grant-image" src="images/dummy.png" alt="grant" id="inside-quantum" />
                   <p>
                     To
@@ -151,7 +159,7 @@
                   <img class="grant-image" src="images/dummy.png" alt="grant" id="qworld" />
                   <p>
                     To Abuzer Yakaryilmaz and the
-                    <a href="https://twitter.com/qworld19">QWorld</a> team to organize
+                    <b><a href="https://twitter.com/qworld19">QWorld</a></b> team to organize
                     <a class="recipient-link" href="https://qworld.net/qcourse511-1/">QCourse511</a>, a graduate-level
                     online course on quantum computing and programming.
                   </p>


### PR DESCRIPTION
- Add grant on QCNN to Matt Tourens to the grants page, with link
- format to bold for name of all recipients