### PR TITLE
use youtube-nocookie

### DIFF
--- a/mitiq.html
+++ b/mitiq.html
@@ -140,7 +140,7 @@
               <iframe
                 width="560"
                 height="315"
-                src="https://www.youtube.com/embed/QK3Vkn2MCCg?start=558"
+                src="https://www.youtube-nocookie.com/embed/QK3Vkn2MCCg?start=558"
                 title="YouTube video player"
                 style="border: none"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/mitiq.html
+++ b/mitiq.html
@@ -140,7 +140,7 @@
               <iframe
                 width="560"
                 height="315"
-                src="https://www.youtube-nocookie.com/embed/QK3Vkn2MCCg?start=558"
+                src="https://www.youtube-nocookie.com/embed/QK3Vkn2MCCg?start=116"
                 title="YouTube video player"
                 style="border: none"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
`youtube-nocookie` is a domain that allows for the embedding of video in a "privacy-enhanced mode".
<img width="377" alt="Screen Shot 2022-08-22 at 2 10 13 PM" src="https://user-images.githubusercontent.com/12703123/186019734-adc3652a-cfc5-4e55-82f0-08cd522005a4.png">

I noticed the video starts in quite a strange place which was introduced in https://github.com/unitaryfund/unitary-fund/pull/162. @willzeng is there a reason you wanted the video to start at that time? If not, another start time might be 116.