### PR TITLE
Add September 2022 grants

### DIFF
--- a/grants.html
+++ b/grants.html
@@ -68,8 +68,8 @@
               </div>
 
               <p>
-                We’ve awarded microgrants to over 61 teams across 23 countries, resulting in 17+ completed or planned
-                publications, welcoming 12 people into the field, and helping to form 2 new startups and 1 new
+                We’ve awarded microgrants to over 68 teams across 23 countries, resulting in 17+ completed or planned
+                publications, welcoming 13 people into the field, and helping to form 2 new startups and 1 new
                 non-profit.
               </p>
 
@@ -87,6 +87,48 @@
 
               <h4 class="grant-year">2022 Grants</h4>
               <ul class="grant-list">
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="dynamic-qcnn" />
+                  <p>
+                    To <b>Stefanie Muroya Lei</b> and <b>Christoph Kirsch</b>, to develop develop QUARC within the Unicorn framework, a bounded model checking that verifies classical programs using the best classical and quantum algorithms.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="dynamic-qcnn" />
+                  <p>
+                    To <b>Omid Khosravanis</b> to develop adaptive quantum process tomography techniques through the use of reinforcement learning.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="dynamic-qcnn" />
+                  <p>
+                    To <b>Kaitlin Gili</b> to conduct an outreach project called Iteration One, sparking curiosity among U.S. high school students with the most limited access to physics and computer science knowledge.
+                  </p>
+                </li>
+                 <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="dynamic-qcnn" />
+                  <p>
+                    To <b>Abdullah Khalid</b> to write a methods focused guide to quantum error correction.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="dynamic-qcnn" />
+                  <p>
+                    To <b>Hong-Ye Hu</b>, <b>Yi-Zhuang You</b>, and <b>Susanne Yelin</b>, to open-source PyClifford, a fast and flexible Python-based Clifford + few T gates simulator.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="dynamic-qcnn" />
+                  <p>
+                    To <b>Tim Weaving</b> and <b>Alexis Ralli</b>, to develop <a href="https://github.com/UCL-CCS/symmer">Symmer</a> into a fully scalable qubit reduction toolkit for the quantum computing community.
+                  </p>
+                </li>
+                <li>
+                  <img class="grant-image" src="images/dummy.png" alt="grant" id="dynamic-qcnn" />
+                  <p>
+                    To <b>Paria Naghavi</b> to add code, visualizations, and conceptual content to the QIR Book, to build knowledge bridges for incoming users to the ecosystem.
+                  </p>
+                </li>
                 <li>
                   <img class="grant-image" src="images/dummy.png" alt="grant" id="dynamic-qcnn" />
                   <p>


### PR DESCRIPTION
Add September 2022 grants:

1. To Stefanie Muroya Lei and Christoph Kirsch (QUARC)
2. To Omid Khosravanis (QPT through RL) 
3. To Kaitlin Gili (Iteration One)
4. To Abdullah Khalid (QEC guide)
5. To Hong-Ye Hu, Yi-Zhuang You, and Susanne Yelin (PyClifford)
6. To Tim Weaving and Alexis Ralli ([Symmer](https://github.com/UCL-CCS/symmer))
7. To Paria Naghavi (QIR book).