### PR TITLE
Add link to job board on careers page

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -71,13 +71,13 @@
               <b>Unitary Fund</b> is always looking for new team members who can help us make quantum tech that benefits
               the most people. See our open listings below!
 
-              <h3> There are no currently open positions</h3>
+              <h4> There are currently no open positions.</h4>
               <br />
               If you don't see a role that's a fit, but think you can help us in our mission, then email us at
               <a href="mailto:info@unitary.fund">info@unitary.fund</a>.
               <br />
 
-              A continuously updated list of work opportunities is available on the <a href="http://discord.unitary.fund">Unitary Fund Discord server</a>, in the <b><a href="https://discord.gg/eQ6C6ZpM">#job-board channel</a></b>.
+              A continuously updated list of work opportunities in the quantum industry from Unitary Fund supporters and partners is available on the <a href="http://discord.unitary.fund">Unitary Fund Discord server</a>, in the <b><a href="https://discord.gg/eQ6C6ZpM">#job-board channel</a></b>.
               <br />
                           
           

--- a/careers.html
+++ b/careers.html
@@ -77,6 +77,11 @@
               <a href="mailto:info@unitary.fund">info@unitary.fund</a>.
               <br />
 
+              A continuously updated list of work opportunities is available on the <a href="http://discord.unitary.fund">Unitary Fund Discord server</a>, in the <br><a href="https://discord.gg/eQ6C6ZpM">#job-board channel</a></br>.
+              <br />
+                          
+              https://discord.gg/eQ6C6ZpM
+
               <footer class="footer leading-arrow light-arrow">
                 This website is hosted on
                 <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community

--- a/careers.html
+++ b/careers.html
@@ -77,11 +77,10 @@
               <a href="mailto:info@unitary.fund">info@unitary.fund</a>.
               <br />
 
-              A continuously updated list of work opportunities is available on the <a href="http://discord.unitary.fund">Unitary Fund Discord server</a>, in the <br><a href="https://discord.gg/eQ6C6ZpM">#job-board channel</a></br>.
+              A continuously updated list of work opportunities is available on the <a href="http://discord.unitary.fund">Unitary Fund Discord server</a>, in the <b><a href="https://discord.gg/eQ6C6ZpM">#job-board channel</a></b>.
               <br />
                           
-              https://discord.gg/eQ6C6ZpM
-
+          
               <footer class="footer leading-arrow light-arrow">
                 This website is hosted on
                 <a href="https://github.com/unitaryfund/unitary-fund" target="_blank">github</a>, and our community


### PR DESCRIPTION
Close #269. It provides more resources for folks looking for job opportunities even when no job openings at UF are available.