### PR TITLE
#279: Link to Metriq 'About' page in menus

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -438,6 +438,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html" class="active">blog</a>
@@ -453,6 +454,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html" class="active">blog</a>

--- a/careers.html
+++ b/careers.html
@@ -134,6 +134,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>
@@ -149,6 +150,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>

--- a/donate.html
+++ b/donate.html
@@ -140,6 +140,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>
@@ -155,6 +156,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>

--- a/faq.html
+++ b/faq.html
@@ -281,6 +281,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html" class="active">faq</a>
                 <a href="blog.html">blog</a>
@@ -296,6 +297,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html" class="active">faq</a>
                 <a href="blog.html">blog</a>

--- a/grants.html
+++ b/grants.html
@@ -865,6 +865,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>
@@ -880,6 +881,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>

--- a/ideas.html
+++ b/ideas.html
@@ -205,6 +205,7 @@
                 <a href="ideas.html" class="active">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>
@@ -220,6 +221,7 @@
                 <a href="ideas.html" class="active">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>

--- a/index.html
+++ b/index.html
@@ -313,6 +313,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>
@@ -328,6 +329,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>

--- a/jobs/chief_of_staff.html
+++ b/jobs/chief_of_staff.html
@@ -206,6 +206,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -221,6 +222,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/jobs/marketing_comm.html
+++ b/jobs/marketing_comm.html
@@ -187,6 +187,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -202,6 +203,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/meetup.html
+++ b/meetup.html
@@ -154,6 +154,7 @@
                 <a href="grants.html">grants</a>
                 <a href="ideas.html" class="active">ideas</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>
@@ -168,6 +169,7 @@
                 <a href="grants.html">grants</a>
                 <a href="ideas.html" class="active">ideas</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>

--- a/mitiq.html
+++ b/mitiq.html
@@ -202,6 +202,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html" class="active">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>
@@ -217,6 +218,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html" class="active">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>

--- a/posts/2020.html
+++ b/posts/2020.html
@@ -155,6 +155,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -170,6 +171,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2020_wittek_prize.html
+++ b/posts/2020_wittek_prize.html
@@ -130,6 +130,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -145,6 +146,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2021-corporate-members.html
+++ b/posts/2021-corporate-members.html
@@ -147,6 +147,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -162,6 +163,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2021.html
+++ b/posts/2021.html
@@ -139,6 +139,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -154,6 +155,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2021_Q1.html
+++ b/posts/2021_Q1.html
@@ -207,6 +207,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -222,6 +223,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2021_Q2.html
+++ b/posts/2021_Q2.html
@@ -204,6 +204,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -219,6 +220,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2021_Q3.html
+++ b/posts/2021_Q3.html
@@ -165,6 +165,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -180,6 +181,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2021_Q4.html
+++ b/posts/2021_Q4.html
@@ -185,6 +185,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -200,6 +201,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2021_ieee_workshops.html
+++ b/posts/2021_ieee_workshops.html
@@ -133,6 +133,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -148,6 +149,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2021_unitaryhack_results.html
+++ b/posts/2021_unitaryhack_results.html
@@ -183,6 +183,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -198,6 +199,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2021_wittek_prize.html
+++ b/posts/2021_wittek_prize.html
@@ -128,6 +128,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -143,6 +144,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022-agnostiq-sponsor.html
+++ b/posts/2022-agnostiq-sponsor.html
@@ -129,6 +129,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -144,6 +145,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_Q1.html
+++ b/posts/2022_Q1.html
@@ -181,6 +181,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -196,6 +197,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_Q2.html
+++ b/posts/2022_Q2.html
@@ -175,6 +175,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -190,6 +191,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_Q3.html
+++ b/posts/2022_Q3.html
@@ -206,6 +206,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -221,6 +222,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_dynamical_decoupling_in_mitiq.html
+++ b/posts/2022_dynamical_decoupling_in_mitiq.html
@@ -129,6 +129,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -144,6 +145,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_free_qpu_access.html
+++ b/posts/2022_free_qpu_access.html
@@ -130,6 +130,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -145,6 +146,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_hodl.html
+++ b/posts/2022_hodl.html
@@ -292,6 +292,7 @@ function main() {
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -307,6 +308,7 @@ function main() {
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_karen_intern_post.html
+++ b/posts/2022_karen_intern_post.html
@@ -206,6 +206,7 @@
                 <a href="../ideas.html">ideas</a>
                 <a href="../research.html">research</a>
                 <a href="../mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="../talks.html">events</a>
                 <a href="../faq.html">faq</a>
                 <a href="../blog.html" class="active">blog</a>
@@ -221,6 +222,7 @@
                 <a href="../ideas.html">ideas</a>
                 <a href="../research.html">research</a>
                 <a href="../mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="../talks.html">events</a>
                 <a href="../faq.html">faq</a>
                 <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_oqupy.html
+++ b/posts/2022_oqupy.html
@@ -167,6 +167,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">talks</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -182,6 +183,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">talks</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_quantum_volume_circuits.html
+++ b/posts/2022_quantum_volume_circuits.html
@@ -127,6 +127,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -142,6 +143,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_survey.html
+++ b/posts/2022_survey.html
@@ -129,6 +129,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -144,6 +145,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_survey_results.html
+++ b/posts/2022_survey_results.html
@@ -174,6 +174,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -189,6 +190,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_unitaryhack_wrapup.html
+++ b/posts/2022_unitaryhack_wrapup.html
@@ -148,6 +148,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -163,6 +164,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022_wittek_prize.html
+++ b/posts/2022_wittek_prize.html
@@ -123,6 +123,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -138,6 +139,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/2022unitaryhack.html
+++ b/posts/2022unitaryhack.html
@@ -163,6 +163,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -178,6 +179,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/Q1_2020.html
+++ b/posts/Q1_2020.html
@@ -197,6 +197,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -212,6 +213,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/Q2_2020.html
+++ b/posts/Q2_2020.html
@@ -198,6 +198,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -213,6 +214,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/Q3_2020.html
+++ b/posts/Q3_2020.html
@@ -197,6 +197,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -212,6 +213,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/Q4_2020.html
+++ b/posts/Q4_2020.html
@@ -203,6 +203,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -218,6 +219,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/advisory_board.html
+++ b/posts/advisory_board.html
@@ -191,6 +191,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -206,6 +207,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/ambassador_alves_intro.html
+++ b/posts/ambassador_alves_intro.html
@@ -149,6 +149,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -164,6 +165,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/ambassador_wahl_intro.html
+++ b/posts/ambassador_wahl_intro.html
@@ -145,6 +145,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -160,6 +161,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/bqskit.html
+++ b/posts/bqskit.html
@@ -201,6 +201,7 @@
                 <a href="../ideas.html">ideas</a>
                 <a href="../research.html">research</a>
                 <a href="../mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="../talks.html">events</a>
                 <a href="../faq.html">faq</a>
                 <a href="../blog.html" class="active">blog</a>
@@ -216,6 +217,7 @@
                 <a href="../ideas.html">ideas</a>
                 <a href="../research.html">research</a>
                 <a href="../mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="../talks.html">events</a>
                 <a href="../faq.html">faq</a>
                 <a href="../blog.html" class="active">blog</a>

--- a/posts/braket.html
+++ b/posts/braket.html
@@ -118,6 +118,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -133,6 +134,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/grant_winner_series.html
+++ b/posts/grant_winner_series.html
@@ -146,6 +146,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -161,6 +162,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/high_school_resources.html
+++ b/posts/high_school_resources.html
@@ -272,6 +272,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -287,6 +288,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/ibmq_access.html
+++ b/posts/ibmq_access.html
@@ -132,6 +132,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -147,6 +148,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/interlin-q.html
+++ b/posts/interlin-q.html
@@ -214,6 +214,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -229,6 +230,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/intern_maria_maryam_post.html
+++ b/posts/intern_maria_maryam_post.html
@@ -132,6 +132,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -147,6 +148,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/krylov.html
+++ b/posts/krylov.html
@@ -146,6 +146,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -161,6 +162,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/metriq_release.html
+++ b/posts/metriq_release.html
@@ -182,6 +182,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -197,6 +198,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/mitiq.html
+++ b/posts/mitiq.html
@@ -180,6 +180,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -195,6 +196,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/mitiq_vqa_performance.html
+++ b/posts/mitiq_vqa_performance.html
@@ -164,6 +164,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -179,6 +180,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/new_version_mitiq_paper.html
+++ b/posts/new_version_mitiq_paper.html
@@ -154,6 +154,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -169,6 +170,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/pandoc-template.html
+++ b/posts/pandoc-template.html
@@ -118,6 +118,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -133,6 +134,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/pasqal.html
+++ b/posts/pasqal.html
@@ -126,6 +126,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -141,6 +142,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/pulser_qutip.html
+++ b/posts/pulser_qutip.html
@@ -126,6 +126,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -141,6 +142,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/qrack_joins_uf.html
+++ b/posts/qrack_joins_uf.html
@@ -127,6 +127,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -142,6 +143,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/quantum_compilers.html
+++ b/posts/quantum_compilers.html
@@ -219,6 +219,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -234,6 +235,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/quantumalgorithmsorg.html
+++ b/posts/quantumalgorithmsorg.html
@@ -169,6 +169,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -184,6 +185,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/qutip_10_years.html
+++ b/posts/qutip_10_years.html
@@ -148,6 +148,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -163,6 +164,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/qutip_2021_annual_report.html
+++ b/posts/qutip_2021_annual_report.html
@@ -132,6 +132,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -147,6 +148,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/uf_ambassadors.html
+++ b/posts/uf_ambassadors.html
@@ -148,6 +148,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -163,6 +164,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/unitary_labs_intro.html
+++ b/posts/unitary_labs_intro.html
@@ -156,6 +156,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -171,6 +172,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/unitaryhack2021.html
+++ b/posts/unitaryhack2021.html
@@ -149,6 +149,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -164,6 +165,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/posts/vqa_in_qutip.html
+++ b/posts/vqa_in_qutip.html
@@ -169,6 +169,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>
@@ -184,6 +185,7 @@
                             <a href="../ideas.html">ideas</a>
                             <a href="../research.html">research</a>
                             <a href="../mitiq.html">mitiq</a>
+                            <a href="https://metriq.info/About">metriq</a>
                             <a href="../talks.html">events</a>
                             <a href="../faq.html">faq</a>
                             <a href="../blog.html" class="active">blog</a>

--- a/research.html
+++ b/research.html
@@ -313,6 +313,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html" class="active">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>
@@ -328,6 +329,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html" class="active">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>

--- a/talks.html
+++ b/talks.html
@@ -567,6 +567,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html" class="active">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>
@@ -582,6 +583,7 @@
                 <a href="ideas.html">ideas</a>
                 <a href="research.html">research</a>
                 <a href="mitiq.html">mitiq</a>
+                <a href="https://metriq.info/About">metriq</a>
                 <a href="talks.html" class="active">events</a>
                 <a href="faq.html">faq</a>
                 <a href="blog.html">blog</a>


### PR DESCRIPTION
This adds Metriq to all menus on the website. (By the way, there obviously has to be a _scalable_ alternative to how we independently re-implement the menu on every single page, but, as a revamp of the site is already a priority that UF has discussed, we just add the same link in _every single page_, for now.)