### PR TITLE
replace addevent with gcal

### DIFF
--- a/talks.html
+++ b/talks.html
@@ -107,12 +107,6 @@
                   <span class="blog-post-date"
                     >7 April, 2022 - 12pm EST/5pm GMT
                     <!-- <a title="Add to Calendar" class="addeventatc" data-id="jg13211859" href="https://www.addevent.com/event/jg13211859" target="_blank" rel="nofollow">Add to Calendar</a> -->
-                    <script
-                      type="text/javascript"
-                      src="https://cdn.addevent.com/libs/atc/1.6.1/atc.min.js"
-                      async
-                      defer
-                    ></script>
                   </span>
                   <h4>
                     <a href="https://qutip.org/docs/latest/guide/guide-qip.html">qutip-qip</a>: Pulse-level circuits

--- a/talks.html
+++ b/talks.html
@@ -71,39 +71,14 @@
                 Want to keep up to date with all the cool stuff the Unitary Fund community is up to? Take a look at the
                 calendar below and add it to your favorite calendar app!
               </p>
-              <div
-                class="ae-emd-cal"
-                data-calendar="kn360162"
-                data-calendars="kn360162"
-                data-calendars-selected="kn360162"
-                data-configure="true"
-                data-title=""
-                data-title-show="true"
-                data-today="true"
-                data-datenav="true"
-                data-date="true"
-                data-monthweektoggle="true"
-                data-subscribebtn="true"
-                data-swimonth="true"
-                data-swiweek="true"
-                data-swischedule="true"
-                data-print="false"
-                data-timezone="true"
-                data-logo="false"
-                data-defaultview="schedule"
-                data-firstday="0"
-                data-datetimeformat="2"
-              ></div>
-              <script type="text/javascript">
-                ;(function () {
-                  var e = document.createElement("script")
-                  e.type = "text/javascript"
-                  e.async = true
-                  e.src = "https://cdn.addevent.com/libs/cal/js/cal.embed.t1.init.js"
-                  e.className = "ae-emd-script"
-                  document.getElementsByTagName("body")[0].appendChild(e)
-                })()
-              </script>
+              <iframe
+                src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=UTC&showPrint=0&showCalendars=0&src=Y19tZ3FkcTZoajJpc2k0ZDZoNDY3a2Zxdmc2MEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%237CB342"
+                style="border-width: 0"
+                width="800"
+                height="600"
+                frameborder="0"
+                scrolling="no"
+              ></iframe>
               <p>
                 Interested in hosting a community call for your project on our Discord? Fill out the
                 <a href="https://airtable.com/shrWtBq9SQWwn4Rar">application form</a>, and we'll get back to you with


### PR DESCRIPTION
This PR is almost a revert of https://github.com/unitaryfund/unitary-fund/pull/196. AddEvent seems to be broken (not sure how, or why), and we don't seem to have access to an AddEvent account/the proper rights to the community calendar to see if it's something related to that. @crazy4pi314 wondering if you had an AddEvent account for UF? If so, something might need to be reconfigured. If this is the case, happy to receive the credentials and reconfigure ourselves.

This may be a temporary workaround, or permanent if AddEvent is now paid or ....