### PR TITLE
Update copyright on all page footers

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -456,7 +456,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">

--- a/careers.html
+++ b/careers.html
@@ -111,7 +111,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020-2022 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">

--- a/donate.html
+++ b/donate.html
@@ -115,7 +115,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">

--- a/faq.html
+++ b/faq.html
@@ -256,7 +256,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">

--- a/fix_copyright_date.sh
+++ b/fix_copyright_date.sh
@@ -1,0 +1,29 @@
+#! /usr/bin/bash
+
+##########################################
+#
+# This script updates the copyright year
+# on all html files. Run the script once
+# a year by calling:
+#     ./fix_copyright_date.sh
+# from a linux command line annually.
+#
+##########################################
+
+CURRENT_YEAR=$(date +"%Y")
+LAST_YEAR=$((CURRENT_YEAR - 1))
+
+fix_year() {
+	sed -i "s/copy;2020-${LAST_YEAR}/copy;2020-${CURRENT_YEAR}/g" ${1}*.html
+}
+
+for D in *; do
+	if [ -d "${D}" ]; then
+		COUNT=`ls -1 ${D}/*.html 2>/dev/null | wc -l`
+		if [ $COUNT != 0 ]; then
+			fix_year "./${D}/"
+		fi
+	fi
+done
+
+fix_year "./"

--- a/grants.html
+++ b/grants.html
@@ -954,7 +954,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">

--- a/ideas.html
+++ b/ideas.html
@@ -180,7 +180,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">

--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">

--- a/jobs/chief_of_staff.html
+++ b/jobs/chief_of_staff.html
@@ -185,7 +185,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2022 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/jobs/marketing_comm.html
+++ b/jobs/marketing_comm.html
@@ -166,7 +166,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/meetup.html
+++ b/meetup.html
@@ -130,7 +130,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">

--- a/mitiq.html
+++ b/mitiq.html
@@ -177,7 +177,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">

--- a/posts/2020.html
+++ b/posts/2020.html
@@ -134,7 +134,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2020_wittek_prize.html
+++ b/posts/2020_wittek_prize.html
@@ -109,7 +109,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2021-corporate-members.html
+++ b/posts/2021-corporate-members.html
@@ -126,7 +126,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2021.html
+++ b/posts/2021.html
@@ -118,7 +118,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2021_Q1.html
+++ b/posts/2021_Q1.html
@@ -190,7 +190,7 @@
                                     <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a></th>
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2021_Q2.html
+++ b/posts/2021_Q2.html
@@ -187,7 +187,7 @@
                                     <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a></th>
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2021_Q3.html
+++ b/posts/2021_Q3.html
@@ -148,7 +148,7 @@
                                     <th style="text-align: right;"><a href="https://www.youtube.com/channel/UCDbDLAzGRTHnhkoMMOX7D1A"><i class="fa fa-youtube"></i></a></th>
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2021_Q4.html
+++ b/posts/2021_Q4.html
@@ -164,7 +164,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2021_ieee_workshops.html
+++ b/posts/2021_ieee_workshops.html
@@ -112,7 +112,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2021_unitaryhack_results.html
+++ b/posts/2021_unitaryhack_results.html
@@ -150,7 +150,7 @@
                                         </a>
                                     </th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2021_wittek_prize.html
+++ b/posts/2021_wittek_prize.html
@@ -107,7 +107,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022-agnostiq-sponsor.html
+++ b/posts/2022-agnostiq-sponsor.html
@@ -108,7 +108,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_Q1.html
+++ b/posts/2022_Q1.html
@@ -160,7 +160,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_Q2.html
+++ b/posts/2022_Q2.html
@@ -154,7 +154,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_Q3.html
+++ b/posts/2022_Q3.html
@@ -185,7 +185,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_Q4.html
+++ b/posts/2022_Q4.html
@@ -164,7 +164,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_ambassadors.html
+++ b/posts/2022_ambassadors.html
@@ -112,7 +112,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_dynamical_decoupling_in_mitiq.html
+++ b/posts/2022_dynamical_decoupling_in_mitiq.html
@@ -108,7 +108,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_free_qpu_access.html
+++ b/posts/2022_free_qpu_access.html
@@ -109,7 +109,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_hodl.html
+++ b/posts/2022_hodl.html
@@ -271,7 +271,7 @@ function main() {
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_karen_intern_post.html
+++ b/posts/2022_karen_intern_post.html
@@ -181,7 +181,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">

--- a/posts/2022_oqupy.html
+++ b/posts/2022_oqupy.html
@@ -146,7 +146,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_quantum_volume_circuits.html
+++ b/posts/2022_quantum_volume_circuits.html
@@ -106,7 +106,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_survey.html
+++ b/posts/2022_survey.html
@@ -108,7 +108,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_survey_results.html
+++ b/posts/2022_survey_results.html
@@ -153,7 +153,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_unitaryhack_wrapup.html
+++ b/posts/2022_unitaryhack_wrapup.html
@@ -127,7 +127,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022_wittek_prize.html
+++ b/posts/2022_wittek_prize.html
@@ -102,7 +102,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2022unitaryhack.html
+++ b/posts/2022unitaryhack.html
@@ -142,7 +142,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2023_hierarqcal.html
+++ b/posts/2023_hierarqcal.html
@@ -157,7 +157,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2023_members.html
+++ b/posts/2023_members.html
@@ -118,7 +118,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2023_metriq_qedc.html
+++ b/posts/2023_metriq_qedc.html
@@ -103,7 +103,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/2023_quarc.html
+++ b/posts/2023_quarc.html
@@ -110,7 +110,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/Q1_2020.html
+++ b/posts/Q1_2020.html
@@ -176,7 +176,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/Q2_2020.html
+++ b/posts/Q2_2020.html
@@ -177,7 +177,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/Q3_2020.html
+++ b/posts/Q3_2020.html
@@ -176,7 +176,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/Q4_2020.html
+++ b/posts/Q4_2020.html
@@ -182,7 +182,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/advisory_board.html
+++ b/posts/advisory_board.html
@@ -170,7 +170,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/ambassador_alves_intro.html
+++ b/posts/ambassador_alves_intro.html
@@ -128,7 +128,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/ambassador_wahl_intro.html
+++ b/posts/ambassador_wahl_intro.html
@@ -124,7 +124,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/bqskit.html
+++ b/posts/bqskit.html
@@ -176,7 +176,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">

--- a/posts/braket.html
+++ b/posts/braket.html
@@ -97,7 +97,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/grant_winner_series.html
+++ b/posts/grant_winner_series.html
@@ -125,7 +125,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/high_school_resources.html
+++ b/posts/high_school_resources.html
@@ -251,7 +251,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/ibmq_access.html
+++ b/posts/ibmq_access.html
@@ -111,7 +111,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/interlin-q.html
+++ b/posts/interlin-q.html
@@ -193,7 +193,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/intern_maria_maryam_post.html
+++ b/posts/intern_maria_maryam_post.html
@@ -111,7 +111,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/krylov.html
+++ b/posts/krylov.html
@@ -125,7 +125,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/metriq_quantum_volume.html
+++ b/posts/metriq_quantum_volume.html
@@ -121,7 +121,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2022 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/metriq_release.html
+++ b/posts/metriq_release.html
@@ -161,7 +161,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2022 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/mitiq.html
+++ b/posts/mitiq.html
@@ -159,7 +159,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/mitiq_vqa_performance.html
+++ b/posts/mitiq_vqa_performance.html
@@ -143,7 +143,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/new_version_mitiq_paper.html
+++ b/posts/new_version_mitiq_paper.html
@@ -133,7 +133,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/pandoc-template.html
+++ b/posts/pandoc-template.html
@@ -97,7 +97,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/pasqal.html
+++ b/posts/pasqal.html
@@ -105,7 +105,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/pulser_qutip.html
+++ b/posts/pulser_qutip.html
@@ -105,7 +105,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/qrack_joins_uf.html
+++ b/posts/qrack_joins_uf.html
@@ -106,7 +106,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/quantum_compilers.html
+++ b/posts/quantum_compilers.html
@@ -198,7 +198,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/quantumalgorithmsorg.html
+++ b/posts/quantumalgorithmsorg.html
@@ -148,7 +148,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/qutip_10_years.html
+++ b/posts/qutip_10_years.html
@@ -127,7 +127,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/qutip_2021_annual_report.html
+++ b/posts/qutip_2021_annual_report.html
@@ -111,7 +111,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/uf_ambassadors.html
+++ b/posts/uf_ambassadors.html
@@ -127,7 +127,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/unitary_labs_intro.html
+++ b/posts/unitary_labs_intro.html
@@ -135,7 +135,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/unitaryhack2021.html
+++ b/posts/unitaryhack2021.html
@@ -128,7 +128,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/posts/vqa_in_qutip.html
+++ b/posts/vqa_in_qutip.html
@@ -148,7 +148,7 @@
                                     <th style="text-align: right;"><a href="http://discord.unitary.fund"><i
                                                 class="fab fa-discord"></i></a></th>
                                 </tr>
-                            </table> &copy;2020 Unitary Fund
+                            </table> &copy;2020-2023 Unitary Fund
                         </footer>
                     </div>
                     <div class="col-1" id="menu-container">

--- a/research.html
+++ b/research.html
@@ -295,7 +295,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020-2022 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">

--- a/talks.html
+++ b/talks.html
@@ -542,7 +542,7 @@
                     </th>
                   </tr>
                 </table>
-                &copy;2020 Unitary Fund
+                &copy;2020-2023 Unitary Fund
               </footer>
             </div>
             <div class="col-1" id="menu-container">


### PR DESCRIPTION
Closes #310

This PR contains two parts:
1. The copyright notice on all html files is updated to read "&copy;2020-2023 Unitary Fund"
2. A simple shell script is added that will update the copyright notice automatically from the previous year to the current calendar year.