### PR TITLE
IBMQ -> IBM Quantum

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -375,7 +375,7 @@
                   <li class="leading-block">
                     <span class="blog-post-date">24 November, 2020</span>
                     <a href="posts/ibmq_access.html"
-                      >Unitary Fund partners with IBM quantum to provide hardware access to Unitary Fund awardees</a
+                      >Unitary Fund partners with IBM Quantum to provide hardware access to Unitary Fund awardees</a
                     >
                   </li>
                   <li class="leading-block">

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
                 Through our partners, we offer free credits to run on Rigetti's
                 <a href="https://docs.rigetti.com/en/">Quantum Cloud Services</a>
                 and priority-tier access to
-                <a href="https://www.ibm.com/quantum-computing/technology/systems">IBMQ's publicly available devices</a
+                <a href="https://www.ibm.com/quantum-computing/technology/systems">IBM Quantum's publicly available devices</a
                 >.
               </p>
               <p>

--- a/mitiq.html
+++ b/mitiq.html
@@ -139,7 +139,7 @@
               </div>
               <p>
                 Practice using calibration by following our tutorial on finding the right error mitigation protocol to
-                use on an IBMQ fake device available
+                use on an IBM Quantum fake device available
                 <a href="https://mitiq.readthedocs.io/en/stable/examples/calibration-tutorial.html">here</a>, or watch
                 the <a href="https://www.youtube.com/watch?v=dB_3R84ewig">video walkthrough</a>!
               </p>

--- a/posts/advisory_board.html
+++ b/posts/advisory_board.html
@@ -148,7 +148,7 @@
                             as a software engineer for RedHat.
                             <br><br>
 
-                            <b>Travis L. Scholten</b> is a quantum computing applications researcher at IBM Quantum, where he also works on collaborations for the IBMQ Network. He received his PhD on quantum characterization, validation, and verification
+                            <b>Travis L. Scholten</b> is a quantum computing applications researcher at IBM Quantum, where he also works on collaborations for the IBM Quantum Network. He received his PhD on quantum characterization, validation, and verification
                             from University of New Mexico and a BS in Physics from Caltech. He has been advising the Unitary Fund's grant program since its inception.
                             <br><br>
 

--- a/posts/ibmq_access.html
+++ b/posts/ibmq_access.html
@@ -72,7 +72,7 @@
                             <br>
 
                             <center>
-                                <h1 class="leading-arrow">Unitary Fund partners with IBM quantum to provide hardware access to Unitary Fund awardees</h1>
+                                <h1 class="leading-arrow">Unitary Fund partners with IBM Quantum to provide hardware access to Unitary Fund awardees</h1>
                             </center>
                             <br>
                             <br> Last edited: 24 November, 2020<br> Unitary Fund Team<br>


### PR DESCRIPTION
Following up on https://github.com/unitaryfund/unitary-fund/pull/236, other instances of _IBMQ_ that should be replaced by _IBM Quantum_.

Thanks!