### PR TITLE
add unitaryHACK banner

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -47,6 +47,10 @@
   </head>
 
   <body>
+    <div class="uhack-banner">
+      <a href="https://unitaryhack.dev/">unitaryHACK</a> is coming <b>May 26-Jun 13</b>! Get rewarded for contributing
+      to open source quantum software!
+    </div>
     <div class="layout">
       <main id="content" class="content">
         <section class="heavy">
@@ -74,7 +78,10 @@
                 <ul style="list-style-type: none">
                   <li class="leading-block">
                     <span class="blog-post-date">2 May, 2023</span>
-                    <a href="posts/eu.html">Unitary Fund to open first European office in Tours (France) in collaboration with Da Vinci Labs</a>
+                    <a href="posts/eu.html"
+                      >Unitary Fund to open first European office in Tours (France) in collaboration with Da Vinci
+                      Labs</a
+                    >
                   </li>
                   <li class="leading-block">
                     <span class="blog-post-date">17 April, 2023</span>
@@ -82,7 +89,9 @@
                   </li>
                   <li class="leading-block">
                     <span class="blog-post-date">11 April, 2023</span>
-                    <a href="posts/2023_Q1.html">Unitary Fund Q1 2023 Update: UF Members, Mitiq and Metriq updates, and new grants</a>
+                    <a href="posts/2023_Q1.html"
+                      >Unitary Fund Q1 2023 Update: UF Members, Mitiq and Metriq updates, and new grants</a
+                    >
                   </li>
                   <li class="leading-block">
                     <span class="blog-post-date">20 March, 2023</span>

--- a/careers.html
+++ b/careers.html
@@ -47,6 +47,10 @@
   </head>
 
   <body>
+    <div class="uhack-banner">
+      <a href="https://unitaryhack.dev/">unitaryHACK</a> is coming <b>May 26-Jun 13</b>! Get rewarded for contributing
+      to open source quantum software!
+    </div>
     <div class="layout">
       <main id="content" class="content">
         <section class="heavy">

--- a/donate.html
+++ b/donate.html
@@ -47,6 +47,10 @@
   </head>
 
   <body>
+    <div class="uhack-banner">
+      <a href="https://unitaryhack.dev/">unitaryHACK</a> is coming <b>May 26-Jun 13</b>! Get rewarded for contributing
+      to open source quantum software!
+    </div>
     <div class="layout">
       <main id="content" class="content">
         <section class="heavy">

--- a/faq.html
+++ b/faq.html
@@ -47,6 +47,10 @@
   </head>
 
   <body>
+    <div class="uhack-banner">
+      <a href="https://unitaryhack.dev/">unitaryHACK</a> is coming <b>May 26-Jun 13</b>! Get rewarded for contributing
+      to open source quantum software!
+    </div>
     <div class="layout">
       <main id="content" class="content">
         <section class="heavy">

--- a/grants.html
+++ b/grants.html
@@ -47,6 +47,10 @@
   </head>
 
   <body>
+    <div class="uhack-banner">
+      <a href="https://unitaryhack.dev/">unitaryHACK</a> is coming <b>May 26-Jun 13</b>! Get rewarded for contributing
+      to open source quantum software!
+    </div>
     <div class="layout">
       <main id="content" class="content">
         <section class="heavy">
@@ -88,40 +92,51 @@
               <h4 class="grant-year">2023 Grants</h4>
 
               <ul class="grant-list">
-
                 <li>
                   <a href="#qutritium"><img class="grant-image" src="images/dummy.png" alt="grant" id="hhat" /></a>
                   <p>
-                    To <b>Son Pham and Tien Nguyen</b> to develop <b><a href="https://github.com/spham1611/qutritium">QuTritium</a></b
-                    >, a Python package that helps automate the calibration process and extends the functionality of the Qiskit package in a qutrit system.
+                    To <b>Son Pham and Tien Nguyen</b> to develop
+                    <b><a href="https://github.com/spham1611/qutritium">QuTritium</a></b
+                    >, a Python package that helps automate the calibration process and extends the functionality of the
+                    Qiskit package in a qutrit system.
                   </p>
-                </li>                
+                </li>
                 <li>
                   <a href="#torchquantum"><img class="grant-image" src="images/dummy.png" alt="grant" id="hhat" /></a>
                   <p>
-                    To <b>Hanrui Wang</b> to further develop <b><a href="https://github.com/mit-han-lab/torchquantum">TorchQuantum</a></b
+                    To <b>Hanrui Wang</b> to further develop
+                    <b><a href="https://github.com/mit-han-lab/torchquantum">TorchQuantum</a></b
                     >, a Quantum classical simulation framework based on PyTorch.
                   </p>
                 </li>
                 <li>
                   <a href="#stac"><img class="grant-image" src="images/dummy.png" alt="grant" id="hhat" /></a>
                   <p>
-                    To <b><a href="https://abdullahkhalid.com/">Abdullah Khalid</a></b> to further develop <b><a href="https://github.com/abdullahkhalids/stac">stac</a></b
+                    To <b><a href="https://abdullahkhalid.com/">Abdullah Khalid</a></b> to further develop
+                    <b><a href="https://github.com/abdullahkhalids/stac">stac</a></b
                     >, a circuit library optimized for building fault-tolerant circuits for stabilizer codes.
                   </p>
                 </li>
                 <li>
                   <a href="#qworld-2023"><img class="grant-image" src="images/dummy.png" alt="grant" id="hhat" /></a>
                   <p>
-                    To <b><a href="http://ultracold.org/menu/">Abuzer Yakaryilmaz</a></b> to foster <b><a href="https://qworld.net/">QWorld</a></b
+                    To <b><a href="http://ultracold.org/menu/">Abuzer Yakaryilmaz</a></b> to foster
+                    <b><a href="https://qworld.net/">QWorld</a></b
                     >'s activites, including QScience Days and QCourses.
                   </p>
                 </li>
                 <li>
                   <a href="#MCTDH"><img class="grant-image" src="images/dummy.png" alt="grant" id="hhat" /></a>
                   <p>
-                    To <b><a href="http://ultracold.org/menu/">Miriam Büttner, Sunayana Dutta, Paolo Molignini, Rui Lin, Camille Lévêque, Axel Lode</a></b> to organize a software developer workshop for the numerical simulation of ultracold quantum many-body systems
-                     (<b><a href="https://gitlab.com/the-mctdh-x-repository/mctdh-x-releases">MCTDH-X</a></b
+                    To
+                    <b
+                      ><a href="http://ultracold.org/menu/"
+                        >Miriam Büttner, Sunayana Dutta, Paolo Molignini, Rui Lin, Camille Lévêque, Axel Lode</a
+                      ></b
+                    >
+                    to organize a software developer workshop for the numerical simulation of ultracold quantum
+                    many-body systems (<b
+                      ><a href="https://gitlab.com/the-mctdh-x-repository/mctdh-x-releases">MCTDH-X</a></b
                     >.
                   </p>
                 </li>

--- a/ideas.html
+++ b/ideas.html
@@ -47,6 +47,10 @@
   </head>
 
   <body>
+    <div class="uhack-banner">
+      <a href="https://unitaryhack.dev/">unitaryHACK</a> is coming <b>May 26-Jun 13</b>! Get rewarded for contributing
+      to open source quantum software!
+    </div>
     <div class="layout">
       <main id="content" class="content">
         <section class="heavy">

--- a/index.html
+++ b/index.html
@@ -43,6 +43,10 @@
   </head>
 
   <body>
+    <div class="uhack-banner">
+      <a href="https://unitaryhack.dev/">unitaryHACK</a> is coming <b>May 26-Jun 13</b>! Get rewarded for contributing
+      to open source quantum software!
+    </div>
     <div class="layout">
       <main id="content" class="content">
         <section class="heavy">
@@ -69,11 +73,7 @@
 
               <p>
                 Read the
-                <b
-                  >
-                  <a href="posts/2022.html" style="background-color: var(--color-yellow)"
-                    >2022 Annual Report</a
-                  ></b
+                <b> <a href="posts/2022.html" style="background-color: var(--color-yellow)">2022 Annual Report</a></b
                 >.
               </p>
 
@@ -185,16 +185,14 @@
               <ul style="list-style-type: none">
                 <li class="leading-block">
                   <b>Core Members:</b>
-                  <a href="https://www.ibm.com/quantum" target="_blank">IBM Quantum</a> and <a href="https://www.scientifica.vc" target="_blank">Scientifica</a>
+                  <a href="https://www.ibm.com/quantum" target="_blank">IBM Quantum</a> and
+                  <a href="https://www.scientifica.vc" target="_blank">Scientifica</a>
                 </li>
                 <li class="leading-block">
                   <b>Supporting Members:</b>
-                  <a href="https://agnostiq.ai/">Agnostiq</a>,
-                  <a href="https://aws.amazon.com/braket/">AWS</a>,
-                  <a href="https://www.cisco.com/">Cisco</a>,
-                  <a href="https://dorahacks.io/">DoraHacks</a>,
-                  <a href="https://www.pasqal.com/">Pasqal</a>,
-                  <a href="https://www.quandela.com/">Quandela</a>,
+                  <a href="https://agnostiq.ai/">Agnostiq</a>, <a href="https://aws.amazon.com/braket/">AWS</a>,
+                  <a href="https://www.cisco.com/">Cisco</a>, <a href="https://dorahacks.io/">DoraHacks</a>,
+                  <a href="https://www.pasqal.com/">Pasqal</a>, <a href="https://www.quandela.com/">Quandela</a>,
                   <a href="https://www.qyber.ai">Qyber</a>
                 </li>
                 <li class="leading-block">
@@ -204,27 +202,22 @@
                   <a href="https://www.bcg.com/">Boston Consulting Group</a>,
                   <a href="https://www.microsoft.com/en-us/">Microsoft</a>,
                   <a href="https://cambridgequantum.com/">Cambridge Quantum Computing</a>,
-                  <a href="https://www.classiq.io/">Classiq</a>,
-                  <a href="https://www.iqt.org/labs/">IQT Labs</a>,
+                  <a href="https://www.classiq.io/">Classiq</a>, <a href="https://www.iqt.org/labs/">IQT Labs</a>,
                   <a href="https://www.rigetti.com/">Rigetti</a>,
                   <a href="https://www.zapatacomputing.com/">Zapata Computing</a>,
                   <a href="https://qcware.com/">QCWare</a>,
                   <a href="http://quantumcomputing.com/">quantumcomputing.com</a>,
-                  <a href="https://www.quera.com/">QuEra</a>,
-                  <a href="https://www.riverlane.com/">Riverlane</a>,
-                  <a href="https://www.xanadu.ai/">Xanadu</a>,
-                  <a href="https://strangeworks.com/">Strangeworks</a>,
+                  <a href="https://www.quera.com/">QuEra</a>, <a href="https://www.riverlane.com/">Riverlane</a>,
+                  <a href="https://www.xanadu.ai/">Xanadu</a>, <a href="https://strangeworks.com/">Strangeworks</a>,
                   <a href="https://www.plos.org/" target="_blank">PLOS</a>,
                   <a href="https://www.meetup.com/New-York-Quantum-Computing-Meetup/" target="_blank"
                     >Steve Willis & NYC Quantum Meetup</a
-                  >,
-                  <a href="https://www.eeroq.com/" target="_blank">EeroQ</a>,
+                  >, <a href="https://www.eeroq.com/" target="_blank">EeroQ</a>,
                   <a href="https://q-ctrl.com/" target="_blank">Q-CTRL</a>
-                  <a href="https://twitter.com/johnhering" target="_blank">John Hering</a>,
-                  Jeff Cordova,
+                  <a href="https://twitter.com/johnhering" target="_blank">John Hering</a>, Jeff Cordova,
                   <a href="https://twitter.com/nalidoust" target="_blank">Nima Alidoust</a>,
-                  <a href="https://www.ornl.gov/staff-profile/travis-s-humble" target="_blank">Travis Humble</a>,
-                  George Umbrarescu, Michał Stęchły, Terrill Frantz, Jordan Rule,
+                  <a href="https://www.ornl.gov/staff-profile/travis-s-humble" target="_blank">Travis Humble</a>, George
+                  Umbrarescu, Michał Stęchły, Terrill Frantz, Jordan Rule,
                   <a href="https://www.zapatacomputing.com/team/greg-ramsay/" target="_blank">Greg Ramsay</a>,
                   <a href="https://www.zapatacomputing.com/team/peter-johnson/" target="_blank">Peter Johnson</a>,
                   <a href="https://twitter.com/quantumverd" target="_blank">Guillaume Verdon</a>,
@@ -263,8 +256,8 @@
                 <a href="posts/advisory_board.html" target="_blank">Advisory Board</a>
                 for helping source and review applications and mentor grant winners! <br /><br />
                 Amira Abbas, Shahnawaz Ahmed, Tomas Babej, Ntwali Bashige, Amy Brown, Stephen DiAdamo, Mark Fingerhuth,
-                Cassandra Granade, Josh Izaac, Sonika Johri, Sarah Kaiser, Nathan Killoran, Peter Karalekas, Ryan LaRose, Roger Luo,
-                Alex McCaskey, Travis L. Scholten, Dylan Sim, Michał Stęchły, Christa Zoufal.
+                Cassandra Granade, Josh Izaac, Sonika Johri, Sarah Kaiser, Nathan Killoran, Peter Karalekas, Ryan
+                LaRose, Roger Luo, Alex McCaskey, Travis L. Scholten, Dylan Sim, Michał Stęchły, Christa Zoufal.
               </p>
               <p class="subtitle leading-arrow">Unitary Fund Team</p>
               <a href="https://www.linkedin.com/in/ben-castanon-96526a14/">Ben Castanon</a>,

--- a/mitiq.html
+++ b/mitiq.html
@@ -75,6 +75,10 @@
   </head>
 
   <body>
+    <div class="uhack-banner">
+      <a href="https://unitaryhack.dev/">unitaryHACK</a> is coming <b>May 26-Jun 13</b>! Get rewarded for contributing
+      to open source quantum software!
+    </div>
     <div class="layout">
       <main id="content" class="content">
         <section class="heavy">

--- a/research.html
+++ b/research.html
@@ -71,6 +71,10 @@
   </head>
 
   <body>
+    <div class="uhack-banner">
+      <a href="https://unitaryhack.dev/">unitaryHACK</a> is coming <b>May 26-Jun 13</b>! Get rewarded for contributing
+      to open source quantum software!
+    </div>
     <div class="layout">
       <main id="content" class="content">
         <section class="heavy">

--- a/style.css
+++ b/style.css
@@ -226,6 +226,12 @@ input {
     /*    border-right: 1px dotted#D8D8D8; */
 }
 
+.uhack-banner {
+    background-color: yellow;
+    text-align: center;
+    padding: 10px 0px;
+}
+
 summary:after {
     content: "+";
     color: #000;

--- a/talks.html
+++ b/talks.html
@@ -47,6 +47,10 @@
   </head>
 
   <body>
+    <div class="uhack-banner">
+      <a href="https://unitaryhack.dev/">unitaryHACK</a> is coming <b>May 26-Jun 13</b>! Get rewarded for contributing
+      to open source quantum software!
+    </div>
     <div class="layout">
       <main id="content" class="content">
         <section class="heavy">


### PR DESCRIPTION
This PR adds a banner to all the top level pages advertising unitaryHACK.

Example:
<img width="1511" alt="Screenshot 2023-05-15 at 1 20 39 PM" src="https://github.com/unitaryfund/unitary-fund/assets/12703123/4fc71d71-2152-4484-b610-48d76782e048">
